### PR TITLE
Fix Bitcoin price chart rendering as flat line

### DIFF
--- a/src/components/BitcoinChart.tsx
+++ b/src/components/BitcoinChart.tsx
@@ -449,7 +449,7 @@ export default function BitcoinChart({ height = 400, showTitle = true, showTrans
           </div>
         ) : (
           <>
-            <div className="flex-1 min-h-0 w-full">
+            <div className="flex-1 min-h-[120px] w-full">
               <ChartContainer config={chartConfig} className="h-full w-full">
                 <ComposedChart data={chartData}>
                   <defs>

--- a/src/lib/dashboard-constants.ts
+++ b/src/lib/dashboard-constants.ts
@@ -37,7 +37,7 @@ export const AVAILABLE_WIDGETS: WidgetDefinition[] = [
     icon: 'LineChart',
     description: 'Real-time Bitcoin price chart with technical indicators',
     minW: 4,
-    minH: 2,
+    minH: 4,
     defaultW: 12,
     defaultH: 4,
     category: 'Market Data',


### PR DESCRIPTION
## Summary
- Set `min-h-[120px]` on the chart container in `BitcoinChart.tsx` to prevent Recharts collapsing to 0px height (which caused all data points to render at the same Y position = flat line at domain maximum)
- Raised `minH` for the `bitcoin-chart` widget from `2` to `4` in `dashboard-constants.ts` so the widget cannot be resized to a height where the chart has no usable space

## Root Cause
With `GRID_ROW_HEIGHT = 80px` and `minH = 2`, the widget could be as short as ~170px. After the CardHeader (~130–160px), legend (~24px), and stats row (~48px), the chart container received 0px or negative height. Recharts then rendered all data points at the same Y coordinate (the domain maximum, $128k) → flat line.

## Test Plan
- [ ] Open Dashboard at http://localhost:3000
- [ ] Verify the Bitcoin price chart shows a proper curve (not a flat line)
- [ ] Resize the chart widget to its minimum size and confirm no flat-line regression
- [ ] Switch between time ranges (1M, 3M, 6M, 1Y) and verify all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)