### PR TITLE
Fix: default transaction currency to user's secondary display currency

### DIFF
--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -187,6 +187,11 @@ export default function AddTransactionModal({
           enabledCurrencies = settingsResult.data.currency.supportedCurrencies;
           console.log('Loaded enabled currencies from settings:', enabledCurrencies);
         }
+
+        // Set default currency to secondary (display) currency for new transactions
+        if (!editingTransaction && settingsResult.success && settingsResult.data?.currency?.secondaryCurrency) {
+          setFormData(prev => ({ ...prev, currency: settingsResult.data.currency.secondaryCurrency }));
+        }
         
         if (customResult.success && customResult.data) {
           customCurrencyList = customResult.data;


### PR DESCRIPTION
## Summary

- The Add Transaction modal always showed USD as the default currency, regardless of the user's settings
- Settings are already fetched in the `loadCurrencies` effect — this PR simply reads `secondaryCurrency` from the response and sets it as the form default for new transactions
- Editing existing transactions is unaffected (the existing transaction's currency is preserved)

## Changes

`src/components/AddTransactionModal.tsx`: after loading settings in `loadCurrencies`, apply `secondaryCurrency` as default currency when `!editingTransaction`

## Test plan

- [ ] Set secondary currency to EUR (or any non-USD) in Settings
- [ ] Open Add Transaction modal → currency field defaults to EUR
- [ ] Edit an existing USD transaction → currency still shows USD

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)