### PR TITLE
Fix: Goals & DCA API use display currency instead of mainCurrency

### DIFF
--- a/src/app/api/goals/[id]/recalculate/route.ts
+++ b/src/app/api/goals/[id]/recalculate/route.ts
@@ -42,18 +42,19 @@ export async function POST(
       const currentPriceData = await BitcoinPriceService.getCurrentPrice();
       const currentBtcPriceUSD = currentPriceData?.price || 100000;
       
-      // Get user's CURRENT main currency (may have changed since goal was created)
+      // Get user's CURRENT display currency (may have changed since goal was created)
       const settings = await SettingsService.getSettings();
       const mainCurrency = settings.currency.mainCurrency;
-      
-      // Convert current BTC price from USD to current main currency
-      const usdToMainRate = await ExchangeRateService.getExchangeRate('USD', mainCurrency);
-      const currentBtcPrice = currentBtcPriceUSD * usdToMainRate;
-      
-      // Convert goal's initial BTC price (stored in goal.currency at creation) to current main currency
-      // This handles cases where user changed their main currency after creating the goal
-      const goalCurrencyToMainRate = await ExchangeRateService.getExchangeRate(goal.currency, mainCurrency);
-      const initialBtcPriceInMain = goal.initialBtcPrice * goalCurrencyToMainRate;
+      const displayCurrency = settings.currency.secondaryCurrency || mainCurrency;
+
+      // Convert current BTC price from USD to display currency
+      const usdToDisplayRate = await ExchangeRateService.getExchangeRate('USD', displayCurrency);
+      const currentBtcPrice = currentBtcPriceUSD * usdToDisplayRate;
+
+      // Convert goal's initial BTC price (stored in goal.currency at creation) to display currency
+      // This handles cases where user changed their display currency after creating the goal
+      const goalCurrencyToDisplayRate = await ExchangeRateService.getExchangeRate(goal.currency, displayCurrency);
+      const initialBtcPriceInMain = goal.initialBtcPrice * goalCurrencyToDisplayRate;
 
       // Calculate remaining time
       const targetDate = new Date(goal.targetDate);
@@ -152,8 +153,8 @@ export async function POST(
       // Compare original vs current (both in mainCurrency now)
       const priceChange = ((currentBtcPrice - initialBtcPriceInMain) / initialBtcPriceInMain) * 100;
       
-      // Convert goal's original monthly amount to current main currency for accurate comparison
-      const originalMonthlyInMain = goal.monthlyFiatNeeded * goalCurrencyToMainRate;
+      // Convert goal's original monthly amount to display currency for accurate comparison
+      const originalMonthlyInMain = goal.monthlyFiatNeeded * goalCurrencyToDisplayRate;
       
       // Use GOAL'S SCENARIO projection to maintain consistency with original calculation
       const monthlyChange = ((goalScenarioProjection.averageMonthlyFiat - originalMonthlyInMain) / originalMonthlyInMain) * 100;
@@ -195,7 +196,7 @@ export async function POST(
             message: isOnTrack 
               ? '✅ You are on track to meet your goal!' 
               : monthlyChange > 0
-                ? `⚠️ Consider increasing monthly investment by ${Math.abs(currentPriceProjection.averageMonthlyFiat - originalMonthlyInMain).toFixed(0)} ${mainCurrency} or extending timeline`
+                ? `⚠️ Consider increasing monthly investment by ${Math.abs(currentPriceProjection.averageMonthlyFiat - originalMonthlyInMain).toFixed(0)} ${displayCurrency} or extending timeline`
                 : '✅ BTC price drop means you can invest less and still meet your goal',
             suggested_monthly: currentPriceProjection.averageMonthlyFiat
           }

--- a/src/app/api/goals/calculate/route.ts
+++ b/src/app/api/goals/calculate/route.ts
@@ -23,11 +23,12 @@ export async function POST(request: NextRequest) {
     const currentPriceData = await BitcoinPriceService.getCurrentPrice();
     const currentBtcPriceUSD = currentPriceData?.price || 100000;
     
-    // Get user's main currency and convert
+    // Get user's display currency and convert
     const settings = await SettingsService.getSettings();
     const mainCurrency = settings.currency.mainCurrency;
-    const usdToMainRate = await ExchangeRateService.getExchangeRate('USD', mainCurrency);
-    const currentBtcPrice = currentBtcPriceUSD * usdToMainRate;
+    const displayCurrency = settings.currency.secondaryCurrency || mainCurrency;
+    const usdToDisplayRate = await ExchangeRateService.getExchangeRate('USD', displayCurrency);
+    const currentBtcPrice = currentBtcPriceUSD * usdToDisplayRate;
     
     // Calculate BTC needed
     const holdings = parseFloat(current_holdings || '0');
@@ -89,7 +90,7 @@ export async function POST(request: NextRequest) {
       success: true,
       data: {
         current_btc_price: currentBtcPrice,
-        currency: mainCurrency,
+        currency: displayCurrency,
         btc_needed: btcNeeded,
         total_months: monthsDiff,
         selected_scenario: selectedScen,

--- a/src/app/api/goals/dca-analysis/route.ts
+++ b/src/app/api/goals/dca-analysis/route.ts
@@ -32,18 +32,16 @@ export async function GET(request: NextRequest) {
       // Get user settings for currency
       const settings = await SettingsService.getSettings();
       const mainCurrency = settings.currency.mainCurrency;
+      const displayCurrency = settings.currency.secondaryCurrency || mainCurrency;
 
-      // Convert BTC price to user's main currency
-      const usdToMainRate = await ExchangeRateService.getExchangeRate('USD', mainCurrency);
-      const currentBtcPrice = currentBtcPriceUSD * usdToMainRate;
+      // Convert BTC price to display currency
+      const usdToDisplayRate = await ExchangeRateService.getExchangeRate('USD', displayCurrency);
+      const currentBtcPrice = currentBtcPriceUSD * usdToDisplayRate;
 
-      // Convert all transaction prices to main currency
+      // Convert all transaction prices to display currency
       const transactionsWithConvertedPrices = await Promise.all(
         transactions.map(async (tx) => {
-          // Get exchange rate from original currency to main currency
-          const rate = await ExchangeRateService.getExchangeRate(tx.originalCurrency, mainCurrency);
-          
-          // Convert prices to main currency
+          const rate = await ExchangeRateService.getExchangeRate(tx.originalCurrency, displayCurrency);
           return {
             ...tx,
             originalPricePerBtc: tx.originalPricePerBtc * rate,
@@ -56,7 +54,7 @@ export async function GET(request: NextRequest) {
       const analysisResult = DCAAnalysisService.analyzeDCA(
         transactionsWithConvertedPrices as any,
         currentBtcPrice,
-        mainCurrency
+        displayCurrency
       );
 
       // Format response
@@ -64,7 +62,7 @@ export async function GET(request: NextRequest) {
         success: true,
         data: {
           ...analysisResult,
-          currency: mainCurrency,
+          currency: displayCurrency,
           analysis_date: new Date().toISOString(),
           total_transactions: transactions.length,
           buy_transactions: transactions.filter(tx => tx.type === 'BUY').length,

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -216,10 +216,31 @@ export default function GoalsPage() {
       const result = await response.json();
       
       if (result.success && result.data) {
-        const btcPrice = result.data.currentBtcPrice;
         const mainCurrency = result.data.mainCurrency || 'USD';
+        const displayCurrency = result.data.secondaryCurrency || mainCurrency;
+        setSelectedCurrency(displayCurrency);
+
+        let btcPrice = result.data.currentBtcPrice;
+        if (mainCurrency !== displayCurrency) {
+          try {
+            const ratesRes = await fetch('/api/exchange-rates');
+            const ratesData = await ratesRes.json();
+            if (ratesData.rates && Array.isArray(ratesData.rates)) {
+              const direct = ratesData.rates.find(
+                (r: any) => r.from_currency === mainCurrency && r.to_currency === displayCurrency
+              );
+              if (direct) {
+                btcPrice = btcPrice * direct.rate;
+              } else {
+                const reverse = ratesData.rates.find(
+                  (r: any) => r.from_currency === displayCurrency && r.to_currency === mainCurrency
+                );
+                if (reverse) btcPrice = btcPrice / reverse.rate;
+              }
+            }
+          } catch { /* keep original price */ }
+        }
         setCurrentBtcPrice(btcPrice);
-        setSelectedCurrency(mainCurrency);
       }
     } catch (error) {
       console.error('Error loading Bitcoin price:', error);
@@ -604,7 +625,6 @@ export default function GoalsPage() {
             {goals.map((goal) => {
               const recalc = goalRecalculations.get(goal.id);
               const isRecalculating = recalculatingGoalId === goal.id;
-              const currencySymbol = goal.currency === 'EUR' ? '€' : '$';
               
               return (
                 <Card key={goal.id} className="overflow-hidden">
@@ -702,7 +722,7 @@ export default function GoalsPage() {
                           <CircleDollarSignIcon className="size-3" /> Monthly
                         </p>
                         <p className="font-semibold text-primary">
-                          {currencySymbol}{goal.monthly_fiat_needed.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                          {formatCurrency(goal.monthly_fiat_needed, goal.currency)}
                         </p>
                       </div>
                       <div className="p-3 bg-muted/50 rounded-lg">

--- a/src/lib/dca-analysis-service.ts
+++ b/src/lib/dca-analysis-service.ts
@@ -108,7 +108,7 @@ export class DCAAnalysisService {
     // Calculate all components
     const timing = this.analyzeTiming(buyTransactions, currentBtcPrice);
     const consistency = this.analyzeConsistency(buyTransactions);
-    const priceDistribution = this.calculatePriceDistribution(buyTransactions, currentBtcPrice);
+    const priceDistribution = this.calculatePriceDistribution(buyTransactions, currentBtcPrice, mainCurrency);
     const whatIfScenarios = this.calculateWhatIfScenarios(buyTransactions, currentBtcPrice);
     const monthlyBreakdown = this.calculateMonthlyBreakdown(buyTransactions);
     const score = this.calculateDCAScore(timing, consistency, buyTransactions, currentBtcPrice);
@@ -352,7 +352,8 @@ export class DCAAnalysisService {
    */
   private static calculatePriceDistribution(
     transactions: BitcoinTransaction[],
-    currentPrice: number
+    currentPrice: number,
+    currency: string = 'USD'
   ): PriceDistribution[] {
     // Find min and max prices
     const prices = transactions.map(tx => tx.originalPricePerBtc);
@@ -360,7 +361,7 @@ export class DCAAnalysisService {
     const maxPrice = Math.max(...prices);
     
     // Create price ranges
-    const ranges = this.createPriceRanges(minPrice, maxPrice, currentPrice);
+    const ranges = this.createPriceRanges(minPrice, maxPrice, currentPrice, currency);
     
     const totalBtc = transactions.reduce((sum, tx) => sum + tx.btcAmount, 0);
     
@@ -383,15 +384,15 @@ export class DCAAnalysisService {
   /**
    * Create price ranges for distribution
    */
-  private static createPriceRanges(minPrice: number, maxPrice: number, currentPrice: number): Array<{min: number, max: number, label: string}> {
+  private static createPriceRanges(minPrice: number, maxPrice: number, currentPrice: number, currency: string = 'USD'): Array<{min: number, max: number, label: string}> {
     const priceRange = maxPrice - minPrice;
     const step = priceRange / 4; // 4 ranges
-    
+
     return [
-      { min: minPrice, max: minPrice + step, label: `${this.formatPrice(minPrice)}-${this.formatPrice(minPrice + step)}` },
-      { min: minPrice + step, max: minPrice + step * 2, label: `${this.formatPrice(minPrice + step)}-${this.formatPrice(minPrice + step * 2)}` },
-      { min: minPrice + step * 2, max: minPrice + step * 3, label: `${this.formatPrice(minPrice + step * 2)}-${this.formatPrice(minPrice + step * 3)}` },
-      { min: minPrice + step * 3, max: maxPrice + 1, label: `${this.formatPrice(minPrice + step * 3)}+` }
+      { min: minPrice, max: minPrice + step, label: `${this.formatPrice(minPrice, currency)}-${this.formatPrice(minPrice + step, currency)}` },
+      { min: minPrice + step, max: minPrice + step * 2, label: `${this.formatPrice(minPrice + step, currency)}-${this.formatPrice(minPrice + step * 2, currency)}` },
+      { min: minPrice + step * 2, max: minPrice + step * 3, label: `${this.formatPrice(minPrice + step * 2, currency)}-${this.formatPrice(minPrice + step * 3, currency)}` },
+      { min: minPrice + step * 3, max: maxPrice + 1, label: `${this.formatPrice(minPrice + step * 3, currency)}+` }
     ];
   }
 
@@ -728,11 +729,16 @@ export class DCAAnalysisService {
   /**
    * Helper: Format price for display
    */
-  private static formatPrice(price: number): string {
+  private static formatPrice(price: number, currency: string = 'USD'): string {
+    const symbols: Record<string, string> = {
+      USD: '$', EUR: '€', GBP: '£', CAD: 'C$', AUD: 'A$',
+      JPY: '¥', CHF: 'CHF ', PLN: 'zł', SEK: 'kr', NOK: 'kr',
+    };
+    const sym = symbols[currency] ?? `${currency} `;
     if (price >= 1000) {
-      return `$${(price / 1000).toFixed(0)}k`;
+      return `${sym}${(price / 1000).toFixed(0)}k`;
     }
-    return `$${price.toFixed(0)}`;
+    return `${sym}${price.toFixed(0)}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

Part of #181

The three Goals API routes were converting prices to `mainCurrency` and returning it as the `currency` field. When the Goals page received this response it set `selectedCurrency` to `mainCurrency` (often USD), overwriting the correct `secondaryCurrency` that had been loaded on page init — causing all subsequent values to display in USD.

## Changes

| File | Change |
|------|--------|
| `api/goals/calculate/route.ts` | Convert BTC price to `secondaryCurrency`, return `displayCurrency` |
| `api/goals/[id]/recalculate/route.ts` | Same; also convert stored goal amounts to `displayCurrency` |
| `api/goals/dca-analysis/route.ts` | Consistent with above (was partially correct) |
| `lib/dca-analysis-service.ts` | Pass `currency` through to `formatPrice()` for distribution range labels |
| `app/goals/page.tsx` | Use `secondaryCurrency` from portfolio-metrics; replace hardcoded `€`/`$` selector with `formatCurrency()` |

## Test plan

- [ ] Set display currency to a non-USD currency (e.g. EUR) in Settings
- [ ] Open `/goals` → DCA Calculator
- [ ] Current BTC price, monthly investment amounts and scenario comparison table show EUR
- [ ] Saved goals show monthly amount in their stored currency
- [ ] Goal recalculation shows BTC price and new monthly amount in EUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)