### PR TITLE
Fix: Dashboard widgets and layout components use display currency

### DIFF
--- a/src/app/api/portfolio-metrics/route.ts
+++ b/src/app/api/portfolio-metrics/route.ts
@@ -33,6 +33,11 @@ export async function GET(request: NextRequest) {
     // Convert BTC price from USD to main currency
     const usdToMainRate = await ExchangeRateService.getExchangeRate('USD', mainCurrency);
     const currentPrice = currentPriceUSD * usdToMainRate;
+
+    // Exchange rate for converting main currency values to secondary currency for display
+    const mainToSecondaryRate = secondaryCurrency && secondaryCurrency !== mainCurrency
+      ? await ExchangeRateService.getExchangeRate(mainCurrency, secondaryCurrency)
+      : 1;
     
     // Separate buy, sell, and transfer transactions
     const buyTransactions = allTransactions.filter(tx => tx.type === 'BUY');
@@ -247,6 +252,7 @@ export async function GET(request: NextRequest) {
       // Currency info
       mainCurrency,
       secondaryCurrency,
+      mainToSecondaryRate,
       
       // Timestamp
       lastUpdated: new Date().toISOString()

--- a/src/components/AutoDCATab.tsx
+++ b/src/components/AutoDCATab.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import RecurringTransactionModal from './RecurringTransactionModal';
 import { cn } from '@/lib/utils';
+import { formatCurrency } from '@/lib/theme';
 
 // shadcn/ui components
 import { Button } from '@/components/ui/button';
@@ -300,9 +301,9 @@ export default function AutoDCATab() {
                     {/* Amount & Stats */}
                     <div className="flex items-center justify-between py-3 border-y">
                       <div>
-                        <p className="text-2xl font-bold">{tx.currency} {tx.amount.toFixed(2)}</p>
+                        <p className="text-2xl font-bold">{formatCurrency(tx.amount, tx.currency)}</p>
                         <p className="text-xs text-muted-foreground">
-                          per {tx.frequency === 'biweekly' ? '2 weeks' : tx.frequency.replace('ly', '')}
+                          per {{ daily: 'day', weekly: 'week', biweekly: '2 weeks', monthly: 'month' }[tx.frequency] ?? tx.frequency}
                         </p>
                       </div>
                       <div className="text-right">
@@ -388,7 +389,7 @@ export default function AutoDCATab() {
                       <div>
                         <p className="font-semibold">{tx.name}</p>
                         <p className="text-sm text-muted-foreground">
-                          {tx.currency} {tx.amount.toFixed(2)} · {formatFrequency(tx.frequency)}
+                          {formatCurrency(tx.amount, tx.currency)} · {formatFrequency(tx.frequency)}
                         </p>
                       </div>
                       <Badge variant="outline" className="text-amber-600 border-amber-500/30">
@@ -483,7 +484,7 @@ export default function AutoDCATab() {
                         </div>
                       </div>
                       <div className="text-right">
-                        <p className="text-sm font-semibold">{exec.originalCurrency} {exec.originalTotalAmount.toFixed(2)}</p>
+                        <p className="text-sm font-semibold">{formatCurrency(exec.originalTotalAmount, exec.originalCurrency)}</p>
                         <p className="text-xs text-muted-foreground">Automatic</p>
                       </div>
                     </div>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -32,6 +32,8 @@ export default function MainContent() {
   const [loadingTransactions, setLoadingTransactions] = useState(true);
   const [loadingPrice, setLoadingPrice] = useState(true);
   const [mainCurrency, setMainCurrency] = useState<string>('USD');
+  const [secondaryCurrency, setSecondaryCurrency] = useState<string>('USD');
+  const [exchangeRate, setExchangeRate] = useState<number>(1);
 
   useEffect(() => {
     const loadPrice = async () => {
@@ -68,8 +70,41 @@ export default function MainContent() {
       }
     };
 
+    const loadCurrencySettings = async () => {
+      try {
+        const [settingsRes, ratesRes] = await Promise.all([
+          fetch('/api/settings'),
+          fetch('/api/exchange-rates'),
+        ]);
+        const settingsData = await settingsRes.json();
+        const ratesData = await ratesRes.json();
+
+        if (settingsData.success && settingsData.data) {
+          const main = settingsData.data.currency?.mainCurrency || 'USD';
+          const secondary = settingsData.data.currency?.secondaryCurrency || main;
+          setMainCurrency(main);
+          setSecondaryCurrency(secondary);
+
+          if (main !== secondary && ratesData.rates && Array.isArray(ratesData.rates)) {
+            const direct = ratesData.rates.find(
+              (r: any) => r.from_currency === main && r.to_currency === secondary
+            );
+            if (direct) {
+              setExchangeRate(direct.rate);
+            } else {
+              const reverse = ratesData.rates.find(
+                (r: any) => r.from_currency === secondary && r.to_currency === main
+              );
+              if (reverse) setExchangeRate(1 / reverse.rate);
+            }
+          }
+        }
+      } catch { /* keep defaults */ }
+    };
+
     loadPrice();
     loadLatestTransactions();
+    loadCurrencySettings();
 
     const unsubscribe = BitcoinPriceClient.onPriceUpdate((newPrice: BitcoinPriceData) => {
       setCurrentBtcPrice(newPrice.price);
@@ -207,13 +242,13 @@ export default function MainContent() {
 
                             {/* Price */}
                             <div className="text-sm">
-                              {formatCurrency(pricePerBtc, mainCurrency)}
+                              {formatCurrency(pricePerBtc * exchangeRate, secondaryCurrency)}
                             </div>
 
                             {/* Current Value */}
                             <div className="text-sm">
                               <div className="font-medium">
-                                {currentValue > 0 ? formatCurrency(currentValue, mainCurrency) : '--'}
+                                {currentValue > 0 ? formatCurrency(currentValue * exchangeRate, secondaryCurrency) : '--'}
                               </div>
                             </div>
 
@@ -222,7 +257,7 @@ export default function MainContent() {
                               {currentValue > 0 ? (
                                 <>
                                   <div className={cn("font-medium", pnl >= 0 ? 'text-profit' : 'text-loss')}>
-                                    {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, mainCurrency)}
+                                    {pnl >= 0 ? '+' : ''}{formatCurrency(pnl * exchangeRate, secondaryCurrency)}
                                   </div>
                                   <div className={cn("text-xs", pnl >= 0 ? 'text-profit' : 'text-loss')}>
                                     {formatPercentage(pnlPercent)}
@@ -258,7 +293,7 @@ export default function MainContent() {
                                 {transaction.btc_amount.toFixed(6)} ₿
                               </div>
                               <div className="text-xs text-muted-foreground">
-                                @ {formatCurrency(pricePerBtc, mainCurrency)}
+                                @ {formatCurrency(pricePerBtc * exchangeRate, secondaryCurrency)}
                               </div>
                             </div>
                           </div>
@@ -266,10 +301,10 @@ export default function MainContent() {
                           {currentValue > 0 && (
                             <div className="flex justify-between items-center pt-2 border-t">
                               <div className="text-xs text-muted-foreground">
-                                Current: {formatCurrency(currentValue, mainCurrency)}
+                                Current: {formatCurrency(currentValue * exchangeRate, secondaryCurrency)}
                               </div>
                               <div className={cn("text-sm font-medium", pnl >= 0 ? 'text-profit' : 'text-loss')}>
-                                {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, mainCurrency)} ({formatPercentage(pnlPercent)})
+                                {pnl >= 0 ? '+' : ''}{formatCurrency(pnl * exchangeRate, secondaryCurrency)} ({formatPercentage(pnlPercent)})
                               </div>
                             </div>
                           )}

--- a/src/components/PortfolioSidebar.tsx
+++ b/src/components/PortfolioSidebar.tsx
@@ -30,7 +30,13 @@ interface ConvertedPortfolioData {
   
   // Secondary currency values
   secondaryCurrency: string;
+  averageBuyPriceSecondary: number;
+  currentBTCPriceSecondary: number;
   currentPortfolioValueSecondary: number;
+  unrealizedPnLSecondary: number;
+  portfolioChange24hSecondary: number;
+  totalInvestedSecondary: number;
+  totalFeesSecondary: number;
 }
 
 interface PortfolioSidebarProps {
@@ -181,7 +187,13 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
       totalFeesMain: portfolioData.totalFeesMain || 0,
       
       secondaryCurrency,
+      averageBuyPriceSecondary: (portfolioData.avgBuyPrice || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
+      currentBTCPriceSecondary: (portfolioData.currentBtcPrice || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
       currentPortfolioValueSecondary: (portfolioData.portfolioValue || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
+      unrealizedPnLSecondary: (portfolioData.unrealizedPnL || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
+      portfolioChange24hSecondary: (portfolioData.portfolioChange24h || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
+      totalInvestedSecondary: (portfolioData.totalInvested || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
+      totalFeesSecondary: (portfolioData.totalFeesMain || 0) * getExchangeRate(mainCurrency, secondaryCurrency),
     };
 
     setConvertedData(converted);
@@ -348,7 +360,7 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
               Avg. Buy Price
             </span>
             <div className="font-mono text-lg font-medium">
-              {formatCurrency(convertedData.averageBuyPriceMain, convertedData.mainCurrency)}
+              {formatCurrency(convertedData.averageBuyPriceSecondary, convertedData.secondaryCurrency)}
             </div>
           </div>
         </CardContent>
@@ -367,7 +379,7 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
             <p className="text-sm text-muted-foreground mb-1">Current Price</p>
             <div className="flex items-baseline justify-between">
               <div className="font-mono text-lg font-bold text-primary">
-                {formatCurrency(convertedData.currentBTCPriceMain, convertedData.mainCurrency)}
+                {formatCurrency(convertedData.currentBTCPriceSecondary, convertedData.secondaryCurrency)}
               </div>
               <div className="flex flex-col items-end">
                 {priceData?.priceChangePercent24h !== undefined ? (
@@ -405,10 +417,10 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
             <p className="text-sm text-muted-foreground mb-1">Portfolio Value</p>
             <div className="space-y-1">
               <div className="font-mono text-lg font-bold">
-                {formatCurrency(convertedData.currentPortfolioValueMain, convertedData.mainCurrency)}
+                {formatCurrency(convertedData.currentPortfolioValueSecondary, convertedData.secondaryCurrency)}
               </div>
               <div className="font-mono text-sm text-muted-foreground">
-                {formatCurrency(convertedData.currentPortfolioValueSecondary, convertedData.secondaryCurrency)}
+                {formatCurrency(convertedData.currentPortfolioValueMain, convertedData.mainCurrency)}
               </div>
             </div>
           </div>
@@ -427,9 +439,9 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
           <div>
             <p className="text-sm text-muted-foreground mb-1">Unrealized P&L</p>
             <div className={`font-mono text-lg font-bold ${
-              convertedData.unrealizedPnLMain >= 0 ? 'text-profit' : 'text-loss'
+              convertedData.unrealizedPnLSecondary >= 0 ? 'text-profit' : 'text-loss'
             }`}>
-              {convertedData.unrealizedPnLMain >= 0 ? '+' : ''}{formatCurrency(convertedData.unrealizedPnLMain, convertedData.mainCurrency)}
+              {convertedData.unrealizedPnLSecondary >= 0 ? '+' : ''}{formatCurrency(convertedData.unrealizedPnLSecondary, convertedData.secondaryCurrency)}
             </div>
             <div className={`text-sm ${
               convertedData.unrealizedPnLPercentage >= 0 ? 'text-profit' : 'text-loss'
@@ -441,10 +453,10 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
           <Separator />
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">24h Change</span>
-            <span className={`text-sm font-medium ${
-              convertedData.portfolioChange24hMain >= 0 ? 'text-profit' : 'text-loss'
+            <span className={`font-mono text-sm font-medium ${
+              convertedData.portfolioChange24hSecondary >= 0 ? 'text-profit' : 'text-loss'
             }`}>
-              {convertedData.portfolioChange24hMain >= 0 ? '+' : '-'}{formatCurrency(Math.abs(convertedData.portfolioChange24hMain), convertedData.mainCurrency)}
+              {convertedData.portfolioChange24hSecondary >= 0 ? '+' : '-'}{formatCurrency(Math.abs(convertedData.portfolioChange24hSecondary), convertedData.secondaryCurrency)}
             </span>
           </div>
         </CardContent>
@@ -461,22 +473,22 @@ export default function PortfolioSidebar({ onClose }: PortfolioSidebarProps) {
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">Total Invested</span>
             <span className="font-mono text-sm font-medium">
-              {formatCurrency(convertedData.totalInvestedMain, convertedData.mainCurrency)}
+              {formatCurrency(convertedData.totalInvestedSecondary, convertedData.secondaryCurrency)}
             </span>
           </div>
-          
+
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">Total Fees</span>
             <span className="font-mono text-sm font-medium">
-              {formatCurrency(convertedData.totalFeesMain, convertedData.mainCurrency)}
+              {formatCurrency(convertedData.totalFeesSecondary, convertedData.secondaryCurrency)}
             </span>
           </div>
-          
+
           <Separator />
           <div className="flex justify-between items-center">
             <span className="text-sm font-medium">Total Cost</span>
             <span className="font-mono text-base font-bold">
-              {formatCurrency(convertedData.totalInvestedMain + convertedData.totalFeesMain, convertedData.mainCurrency)}
+              {formatCurrency(convertedData.totalInvestedSecondary + convertedData.totalFeesSecondary, convertedData.secondaryCurrency)}
             </span>
           </div>
         </CardContent>

--- a/src/components/widgets/AutoDCAWidget.tsx
+++ b/src/components/widgets/AutoDCAWidget.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { WidgetProps } from '@/lib/dashboard-types';
 import { BotIcon, CalendarIcon, CheckCircleIcon, ClockIcon, ExternalLinkIcon, PauseIcon } from 'lucide-react';
+import { formatCurrency } from '@/lib/theme';
 import Link from 'next/link';
 
 interface RecurringTransaction {
@@ -180,7 +181,7 @@ export default function AutoDCAWidget({ id, onRefresh }: WidgetProps) {
                         {tx.name}
                       </div>
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <span>{tx.currency} {tx.amount.toFixed(0)}</span>
+                        <span>{formatCurrency(tx.amount, tx.currency)}</span>
                         <span>•</span>
                         <span className="capitalize">{tx.frequency}</span>
                       </div>
@@ -233,7 +234,7 @@ export default function AutoDCAWidget({ id, onRefresh }: WidgetProps) {
                         </div>
                       </div>
                       <div className="text-xs font-semibold text-muted-foreground">
-                        {exec.originalCurrency} {exec.originalTotalAmount.toFixed(0)}
+                        {formatCurrency(exec.originalTotalAmount, exec.originalCurrency)}
                       </div>
                     </div>
                   ))}

--- a/src/components/widgets/DCAAnalysisWidget.tsx
+++ b/src/components/widgets/DCAAnalysisWidget.tsx
@@ -8,6 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { Progress } from '@/components/ui/progress';
 import { WidgetProps } from '@/lib/dashboard-types';
 import { TrendingUpIcon, TargetIcon, ExternalLinkIcon } from 'lucide-react';
+import { formatCurrency } from '@/lib/theme';
 import Link from 'next/link';
 
 interface DCAAnalysis {
@@ -191,8 +192,7 @@ export default function DCAAnalysisWidget({ id, onRefresh }: WidgetProps) {
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Avg Buy</p>
                 <div className="text-lg font-bold text-btc-500">
-                  {analysis.currency === 'EUR' ? '€' : '$'}
-                  {analysis.summary.avgBuyPrice.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  {formatCurrency(analysis.summary.avgBuyPrice, analysis.currency)}
                 </div>
               </div>
             )}

--- a/src/components/widgets/LatestTransactionsWidget.tsx
+++ b/src/components/widgets/LatestTransactionsWidget.tsx
@@ -35,12 +35,47 @@ export default function LatestTransactionsWidget({ id, onRefresh }: WidgetProps)
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [mainCurrency, setMainCurrency] = useState<string>('USD');
+  const [secondaryCurrency, setSecondaryCurrency] = useState<string>('USD');
+  const [exchangeRate, setExchangeRate] = useState<number>(1);
   const [currentBtcPrice, setCurrentBtcPrice] = useState<number>(0);
   const [maxTransactions] = useState<number>(5);
 
   useEffect(() => {
     loadLatestTransactions();
     loadCurrentPrice();
+
+    const loadCurrencySettings = async () => {
+      try {
+        const [settingsRes, ratesRes] = await Promise.all([
+          fetch('/api/settings'),
+          fetch('/api/exchange-rates'),
+        ]);
+        const settingsData = await settingsRes.json();
+        const ratesData = await ratesRes.json();
+
+        if (settingsData.success && settingsData.data) {
+          const main = settingsData.data.currency?.mainCurrency || 'USD';
+          const secondary = settingsData.data.currency?.secondaryCurrency || main;
+          setMainCurrency(main);
+          setSecondaryCurrency(secondary);
+
+          if (main !== secondary && ratesData.rates && Array.isArray(ratesData.rates)) {
+            const direct = ratesData.rates.find(
+              (r: any) => r.from_currency === main && r.to_currency === secondary
+            );
+            if (direct) {
+              setExchangeRate(direct.rate);
+            } else {
+              const reverse = ratesData.rates.find(
+                (r: any) => r.from_currency === secondary && r.to_currency === main
+              );
+              if (reverse) setExchangeRate(1 / reverse.rate);
+            }
+          }
+        }
+      } catch { /* keep defaults */ }
+    };
+    loadCurrencySettings();
 
     // Subscribe to price updates
     const unsubscribe = BitcoinPriceClient.onPriceUpdate((newPrice) => {
@@ -137,7 +172,7 @@ export default function LatestTransactionsWidget({ id, onRefresh }: WidgetProps)
                       {transaction.btc_amount.toFixed(6)} ₿
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      @ {formatCurrency(pricePerBtc, mainCurrency)}
+                      @ {formatCurrency(pricePerBtc * exchangeRate, secondaryCurrency)}
                     </div>
                   </div>
                 </div>
@@ -146,7 +181,7 @@ export default function LatestTransactionsWidget({ id, onRefresh }: WidgetProps)
                   <div className="flex justify-between items-center text-xs">
                     <span className="text-muted-foreground">P&L:</span>
                     <span className={`font-medium ${pnl >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                      {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, mainCurrency)} ({formatPercentage(pnlPercent)})
+                      {pnl >= 0 ? '+' : ''}{formatCurrency(pnl * exchangeRate, secondaryCurrency)} ({formatPercentage(pnlPercent)})
                     </span>
                   </div>
                 )}

--- a/src/components/widgets/MultiTimeframeWidget.tsx
+++ b/src/components/widgets/MultiTimeframeWidget.tsx
@@ -46,8 +46,10 @@ export default function MultiTimeframeWidget({ id, onRefresh }: WidgetProps) {
       
       if (result.success && result.data) {
         const data = result.data;
-        setCurrency(data.mainCurrency);
-        setCurrentPrice(data.currentBtcPrice);
+        const displayCurrency = data.secondaryCurrency || data.mainCurrency;
+        const rate = data.mainToSecondaryRate || 1;
+        setCurrency(displayCurrency);
+        setCurrentPrice(data.currentBtcPrice * rate);
 
         // Calculate performance for different timeframes
         // For now, we'll use the 24h data and simulate others
@@ -56,31 +58,31 @@ export default function MultiTimeframeWidget({ id, onRefresh }: WidgetProps) {
           {
             period: '24h',
             label: '24 Hours',
-            change: data.portfolioChange24h || 0,
+            change: (data.portfolioChange24h || 0) * rate,
             changePercent: data.portfolioChange24hPercent || 0
           },
           {
             period: '7d',
             label: '7 Days',
-            change: (data.portfolioChange24h || 0) * 3.2, // Simulated
+            change: (data.portfolioChange24h || 0) * rate * 3.2, // Simulated
             changePercent: (data.portfolioChange24hPercent || 0) * 3.2
           },
           {
             period: '30d',
             label: '30 Days',
-            change: (data.portfolioChange24h || 0) * 8.5, // Simulated
+            change: (data.portfolioChange24h || 0) * rate * 8.5, // Simulated
             changePercent: (data.portfolioChange24hPercent || 0) * 8.5
           },
           {
             period: '1y',
             label: '1 Year',
-            change: data.totalPnL || 0, // Use actual total P&L
+            change: (data.totalPnL || 0) * rate, // Use actual total P&L
             changePercent: data.roi || 0
           },
           {
             period: 'ath',
             label: 'All Time',
-            change: data.totalPnL || 0,
+            change: (data.totalPnL || 0) * rate,
             changePercent: data.roi || 0
           }
         ];

--- a/src/components/widgets/PortfolioSummaryWidget.tsx
+++ b/src/components/widgets/PortfolioSummaryWidget.tsx
@@ -20,6 +20,8 @@ interface PortfolioMetrics {
   avgBuyPrice: number;
   avgSellPrice: number;
   mainCurrency: string;
+  secondaryCurrency?: string;
+  mainToSecondaryRate?: number;
   portfolioChange24h: number;
   portfolioChange24hPercent: number;
   totalTransactions: number;
@@ -67,7 +69,8 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
     onRefresh?.();
   };
 
-  const currency = metrics?.mainCurrency || 'USD';
+  const currency = metrics?.secondaryCurrency || metrics?.mainCurrency || 'USD';
+  const rate = metrics?.mainToSecondaryRate || 1;
 
   return (
     <WidgetCard
@@ -85,7 +88,7 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
           <div>
             <p className="text-xs text-muted-foreground mb-1">Total Holdings</p>
             <div className="text-lg font-bold">{metrics.totalBtc.toFixed(8)} ₿</div>
-            <div className="text-xs text-muted-foreground">{formatCurrency(metrics.portfolioValue, currency)}</div>
+            <div className="text-xs text-muted-foreground">{formatCurrency(metrics.portfolioValue * rate, currency)}</div>
           </div>
 
           <Separator />
@@ -102,7 +105,7 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
               <div className={`text-base font-bold ${
                 metrics.totalPnL >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
               }`}>
-                {metrics.totalPnL >= 0 ? '+' : ''}{formatCurrency(metrics.totalPnL, currency)}
+                {metrics.totalPnL >= 0 ? '+' : ''}{formatCurrency(metrics.totalPnL * rate, currency)}
               </div>
             </div>
             <div className={`text-xs ${
@@ -121,7 +124,7 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
               <span className={`text-xs font-medium ${
                 metrics.unrealizedPnL >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
               }`}>
-                {metrics.unrealizedPnL >= 0 ? '+' : ''}{formatCurrency(metrics.unrealizedPnL, currency)}
+                {metrics.unrealizedPnL >= 0 ? '+' : ''}{formatCurrency(metrics.unrealizedPnL * rate, currency)}
               </span>
             </div>
             <div className="flex justify-between items-center">
@@ -129,7 +132,7 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
               <span className={`text-xs font-medium ${
                 metrics.realizedPnL >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
               }`}>
-                {metrics.realizedPnL >= 0 ? '+' : ''}{formatCurrency(metrics.realizedPnL, currency)}
+                {metrics.realizedPnL >= 0 ? '+' : ''}{formatCurrency(metrics.realizedPnL * rate, currency)}
               </span>
             </div>
           </div>
@@ -143,7 +146,7 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
                 <div className={`text-sm font-semibold ${
                   metrics.portfolioChange24h >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                 }`}>
-                  {metrics.portfolioChange24h >= 0 ? '+' : ''}{formatCurrency(metrics.portfolioChange24h, currency)}
+                  {metrics.portfolioChange24h >= 0 ? '+' : ''}{formatCurrency(metrics.portfolioChange24h * rate, currency)}
                   <span className="ml-1 text-xs">
                     ({metrics.portfolioChange24hPercent >= 0 ? '+' : ''}{metrics.portfolioChange24hPercent.toFixed(2)}%)
                   </span>
@@ -158,11 +161,11 @@ export default function PortfolioSummaryWidget({ id, onRefresh }: WidgetProps) {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-xs text-muted-foreground">Avg Buy</span>
-              <span className="text-xs font-medium">{formatCurrency(metrics.avgBuyPrice, currency)}</span>
+              <span className="text-xs font-medium">{formatCurrency(metrics.avgBuyPrice * rate, currency)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-xs text-muted-foreground">Current</span>
-              <span className="text-xs font-medium text-btc-500">{formatCurrency(metrics.currentBtcPrice, currency)}</span>
+              <span className="text-xs font-medium text-btc-500">{formatCurrency(metrics.currentBtcPrice * rate, currency)}</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

Part of #181

All dashboard widgets and layout components were formatting monetary values with `mainCurrency` (USD). This PR fixes the display across all dashboard components.

## Approach

`/api/portfolio-metrics` now computes and returns a `mainToSecondaryRate` field so components can convert values without an additional API call.

## Changes

| File | Change |
|------|--------|
| `api/portfolio-metrics/route.ts` | Add `mainToSecondaryRate` to response |
| `PortfolioSummaryWidget` | Use `secondaryCurrency` + `mainToSecondaryRate` for all values |
| `MultiTimeframeWidget` | Same — current price and timeframe change amounts |
| `LatestTransactionsWidget` | Same — transaction price, current value, P&L |
| `AutoDCAWidget` | Use `formatCurrency(amount, tx.currency)` for recurring amounts |
| `DCAAnalysisWidget` | Replace hardcoded `€`/`$` selector with `formatCurrency()` |
| `MainContent.tsx` | Transaction table: price, current value, P&L columns |
| `PortfolioSidebar.tsx` | Current price, portfolio value, P&L, invested, fees |
| `AutoDCATab.tsx` | Recurring amounts and execution history rows |

## Test plan

- [ ] Set display currency to EUR in Settings
- [ ] Dashboard: Portfolio Summary shows all values in EUR
- [ ] Dashboard: Multi-Timeframe Performance shows EUR amounts
- [ ] Dashboard: Latest Transactions widget shows EUR prices and P&L
- [ ] Dashboard: Auto DCA widget shows EUR amounts
- [ ] Portfolio sidebar: price, value, P&L all in EUR
- [ ] Main content transaction list: price, value, P&L in EUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)