### PR TITLE
Fix: Analytics and Transactions pages use display currency

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -81,6 +81,8 @@ export default function AnalyticsPage() {
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [mainCurrency, setMainCurrency] = useState('USD');
+  const [secondaryCurrency, setSecondaryCurrency] = useState('USD');
+  const [exchangeRate, setExchangeRate] = useState(1);
   const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
@@ -128,7 +130,30 @@ export default function AnalyticsPage() {
             }
           };
           setAnalyticsData(transformedData);
-          setMainCurrency(result.data.mainCurrency || 'USD');
+          const main = result.data.mainCurrency || 'USD';
+          const secondary = result.data.secondaryCurrency || main;
+          setMainCurrency(main);
+          setSecondaryCurrency(secondary);
+
+          if (main !== secondary) {
+            try {
+              const ratesRes = await fetch('/api/exchange-rates');
+              const ratesData = await ratesRes.json();
+              if (ratesData.rates && Array.isArray(ratesData.rates)) {
+                const direct = ratesData.rates.find(
+                  (r: any) => r.from_currency === main && r.to_currency === secondary
+                );
+                if (direct) {
+                  setExchangeRate(direct.rate);
+                } else {
+                  const reverse = ratesData.rates.find(
+                    (r: any) => r.from_currency === secondary && r.to_currency === main
+                  );
+                  if (reverse) setExchangeRate(1 / reverse.rate);
+                }
+              }
+            } catch { /* keep rate = 1 */ }
+          }
         }
       }
     } catch (error) {
@@ -138,10 +163,12 @@ export default function AnalyticsPage() {
     }
   };
 
-  const formatCurrency = (value: number | undefined, currency: string = mainCurrency) => {
+  const formatCurrency = (value: number | undefined, currency: string = secondaryCurrency) => {
     if (value === undefined || value === null) return `${getCurrencySymbol(currency)}0`;
     return `${getCurrencySymbol(currency)}${Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
   };
+
+  const fc = (value: number | undefined) => formatCurrency(value !== undefined ? value * exchangeRate : undefined);
 
   const getCurrencySymbol = (currency: string) => {
     const currencyData = currencies.find(c => c.alpha === currency);
@@ -290,9 +317,9 @@ export default function AnalyticsPage() {
                     "text-2xl font-bold mt-1",
                     analyticsData?.totalPnL && analyticsData.totalPnL >= 0 ? 'text-profit' : 'text-loss'
                   )}>
-                    {analyticsData?.totalPnL 
-                      ? `${analyticsData.totalPnL >= 0 ? '+' : '-'}${formatCurrency(Math.abs(analyticsData.totalPnL))}`
-                      : formatCurrency(0)}
+                    {analyticsData?.totalPnL
+                      ? `${analyticsData.totalPnL >= 0 ? '+' : '-'}${fc(Math.abs(analyticsData.totalPnL))}`
+                      : fc(0)}
                   </p>
                   <p className={cn(
                     "text-sm font-medium mt-1",
@@ -324,9 +351,9 @@ export default function AnalyticsPage() {
                     "text-2xl font-bold mt-1",
                     analyticsData?.unrealizedPnL && analyticsData.unrealizedPnL >= 0 ? 'text-profit' : 'text-loss'
                   )}>
-                    {analyticsData?.unrealizedPnL 
-                      ? `${analyticsData.unrealizedPnL >= 0 ? '+' : '-'}${formatCurrency(Math.abs(analyticsData.unrealizedPnL))}`
-                      : formatCurrency(0)}
+                    {analyticsData?.unrealizedPnL
+                      ? `${analyticsData.unrealizedPnL >= 0 ? '+' : '-'}${fc(Math.abs(analyticsData.unrealizedPnL))}`
+                      : fc(0)}
                   </p>
                   <p className="text-xs text-muted-foreground mt-1">Current holdings</p>
                 </div>
@@ -347,9 +374,9 @@ export default function AnalyticsPage() {
                     "text-2xl font-bold mt-1",
                     analyticsData?.realizedPnL && analyticsData.realizedPnL >= 0 ? 'text-profit' : 'text-loss'
                   )}>
-                    {analyticsData?.realizedPnL 
-                      ? `${analyticsData.realizedPnL >= 0 ? '+' : '-'}${formatCurrency(Math.abs(analyticsData.realizedPnL))}`
-                      : formatCurrency(0)}
+                    {analyticsData?.realizedPnL
+                      ? `${analyticsData.realizedPnL >= 0 ? '+' : '-'}${fc(Math.abs(analyticsData.realizedPnL))}`
+                      : fc(0)}
                   </p>
                   <p className="text-xs text-muted-foreground mt-1">Closed positions</p>
                 </div>
@@ -389,7 +416,7 @@ export default function AnalyticsPage() {
           <Card>
             <CardContent className="p-5">
               <p className="text-sm font-medium text-muted-foreground">Average Buy Price</p>
-              <p className="text-xl font-bold mt-1">{formatCurrency(analyticsData?.avgBuyPrice)}</p>
+              <p className="text-xl font-bold mt-1">{fc(analyticsData?.avgBuyPrice)}</p>
               <p className="text-xs text-muted-foreground mt-1">Cost basis</p>
             </CardContent>
           </Card>
@@ -397,7 +424,7 @@ export default function AnalyticsPage() {
           <Card className="bg-gradient-to-br from-btc-500/10 to-btc-600/5 border-btc-500/20">
             <CardContent className="p-5">
               <p className="text-sm font-medium text-muted-foreground">Current BTC Price</p>
-              <p className="text-xl font-bold text-btc-500 mt-1">{formatCurrency(analyticsData?.currentBtcPrice)}</p>
+              <p className="text-xl font-bold text-btc-500 mt-1">{fc(analyticsData?.currentBtcPrice)}</p>
               <p className="text-xs text-muted-foreground mt-1">Live market price</p>
             </CardContent>
           </Card>
@@ -486,7 +513,7 @@ export default function AnalyticsPage() {
                                 <div 
                                   className="w-full bg-profit hover:bg-profit/80 rounded-t transition-all cursor-pointer"
                                   style={{ height: `${heightPercent}%`, minHeight: '4px' }}
-                                  title={`${month.monthName}: ${month.btcAmount?.toFixed(6)} BTC @ ${formatCurrency(month.avgBuyPrice)} (${month.percentGain >= 0 ? '+' : ''}${month.percentGain.toFixed(1)}%)`}
+                                  title={`${month.monthName}: ${month.btcAmount?.toFixed(6)} BTC @ ${fc(month.avgBuyPrice)} (${month.percentGain >= 0 ? '+' : ''}${month.percentGain.toFixed(1)}%)`}
                                 />
                               )}
                             </div>
@@ -506,7 +533,7 @@ export default function AnalyticsPage() {
                                 <div 
                                   className="w-full bg-loss hover:bg-loss/80 rounded-b transition-all cursor-pointer"
                                   style={{ height: `${heightPercent}%`, minHeight: '4px' }}
-                                  title={`${month.monthName}: ${month.btcAmount?.toFixed(6)} BTC @ ${formatCurrency(month.avgBuyPrice)} (${month.percentGain.toFixed(1)}%)`}
+                                  title={`${month.monthName}: ${month.btcAmount?.toFixed(6)} BTC @ ${fc(month.avgBuyPrice)} (${month.percentGain.toFixed(1)}%)`}
                                 />
                               )}
                               <div className="text-center mt-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -158,8 +158,10 @@ export default function TransactionsPage() {
     sellTransactionCount: 0,
     totalInvested: 0,
     totalPnL: 0,
-    mainCurrency: 'USD'
+    mainCurrency: 'USD',
+    secondaryCurrency: 'USD',
   });
+  const [secondaryExchangeRate, setSecondaryExchangeRate] = useState(1);
   const [dateRange, setDateRange] = useState<'all' | '7d' | '30d' | '3m' | '1y' | 'custom'>('all');
   const [customDateFrom, setCustomDateFrom] = useState<string>('');
   const [customDateTo, setCustomDateTo] = useState<string>('');
@@ -298,15 +300,41 @@ export default function TransactionsPage() {
       
       if (result.success && result.data) {
         const metrics = result.data;
-        
+        const mainCurrency = metrics.mainCurrency || 'USD';
+        const secondaryCurrency = metrics.secondaryCurrency || mainCurrency;
+
+        // Fetch exchange rate main → secondary
+        let rate = 1;
+        if (mainCurrency !== secondaryCurrency) {
+          try {
+            const rateRes = await fetch('/api/exchange-rates');
+            const rateData = await rateRes.json();
+            if (rateData.rates && Array.isArray(rateData.rates)) {
+              const direct = rateData.rates.find(
+                (r: any) => r.from_currency === mainCurrency && r.to_currency === secondaryCurrency
+              );
+              if (direct) {
+                rate = direct.rate;
+              } else {
+                const reverse = rateData.rates.find(
+                  (r: any) => r.from_currency === secondaryCurrency && r.to_currency === mainCurrency
+                );
+                if (reverse) rate = 1 / reverse.rate;
+              }
+            }
+          } catch { /* keep rate = 1 */ }
+        }
+        setSecondaryExchangeRate(rate);
+
         setSummaryStats({
-          totalBtcBought: metrics.totalBtc + (metrics.totalBtcSold || 0), // Approximate from holdings
-          totalBtcSold: 0, // Will be calculated from transactions if needed
+          totalBtcBought: metrics.totalBtc + (metrics.totalBtcSold || 0),
+          totalBtcSold: 0,
           buyTransactionCount: metrics.totalBuys || 0,
           sellTransactionCount: metrics.totalSells || 0,
           totalInvested: metrics.totalInvested || 0,
           totalPnL: metrics.unrealizedPnL || 0,
-          mainCurrency: metrics.mainCurrency || 'USD'
+          mainCurrency,
+          secondaryCurrency,
         });
       }
     } catch (error) {
@@ -633,7 +661,7 @@ export default function TransactionsPage() {
                   <p className="text-sm font-medium text-muted-foreground">Net Holdings</p>
                   <p className="text-3xl font-bold text-btc-500 mt-1">{netPosition.toFixed(8)} BTC</p>
                   <p className="text-sm text-muted-foreground mt-1">
-                    ≈ {formatCurrency(netPosition * currentBtcPrice, summaryStats.mainCurrency)}
+                    ≈ {formatCurrency(netPosition * currentBtcPrice * secondaryExchangeRate, summaryStats.secondaryCurrency)}
                   </p>
                 </div>
                 <div className="p-3 bg-btc-500/10 rounded-xl">
@@ -659,7 +687,7 @@ export default function TransactionsPage() {
               <div className="flex items-start justify-between">
                 <div>
                   <p className="text-sm font-medium text-muted-foreground">Total Invested</p>
-                  <p className="text-2xl font-bold mt-1">{formatCurrency(summaryStats.totalInvested, summaryStats.mainCurrency)}</p>
+                  <p className="text-2xl font-bold mt-1">{formatCurrency(summaryStats.totalInvested * secondaryExchangeRate, summaryStats.secondaryCurrency)}</p>
                 </div>
                 <div className="p-2.5 bg-muted rounded-lg">
                   <CoinsIcon className="size-5 text-muted-foreground" />
@@ -667,7 +695,7 @@ export default function TransactionsPage() {
               </div>
               <div className="mt-3">
                 <p className="text-xs text-muted-foreground">Avg. Buy Price</p>
-                <p className="text-sm font-medium">{avgBuyPrice > 0 ? formatCurrency(avgBuyPrice, summaryStats.mainCurrency) : '—'}</p>
+                <p className="text-sm font-medium">{avgBuyPrice > 0 ? formatCurrency(avgBuyPrice * secondaryExchangeRate, summaryStats.secondaryCurrency) : '—'}</p>
               </div>
             </CardContent>
           </Card>
@@ -679,7 +707,7 @@ export default function TransactionsPage() {
                 <div>
                   <p className="text-sm font-medium text-muted-foreground">Unrealized P&L</p>
                   <p className={cn("text-2xl font-bold mt-1", summaryStats.totalPnL >= 0 ? 'text-profit' : 'text-loss')}>
-                    {summaryStats.totalPnL >= 0 ? '+' : ''}{formatCurrency(summaryStats.totalPnL, summaryStats.mainCurrency)}
+                    {summaryStats.totalPnL >= 0 ? '+' : ''}{formatCurrency(summaryStats.totalPnL * secondaryExchangeRate, summaryStats.secondaryCurrency)}
                   </p>
                 </div>
                 <div className={cn("p-2.5 rounded-lg", summaryStats.totalPnL >= 0 ? 'bg-profit/10' : 'bg-loss/10')}>
@@ -980,10 +1008,12 @@ export default function TransactionsPage() {
             ) : (
               <div className="divide-y">
                 {filteredAndSortedTransactions.map((transaction) => {
-                  const pnl = calculatePnL(transaction);
+                  const pnl = transaction.secondary_currency_pnl ?? (calculatePnL(transaction) * secondaryExchangeRate);
                   const pnlPercent = calculatePnLPercent(transaction);
                   const isSelected = selectedTransactions.has(transaction.id);
-                  const currentValue = transaction.current_value_main || (transaction.btc_amount * currentBtcPrice);
+                  const currentValue = transaction.secondary_currency_current_value ?? ((transaction.current_value_main || (transaction.btc_amount * currentBtcPrice)) * secondaryExchangeRate);
+                  const totalAmount = transaction.secondary_currency_total_amount ?? (transaction.main_currency_total_amount * secondaryExchangeRate);
+                  const displayCurrency = transaction.secondary_currency || summaryStats.secondaryCurrency;
 
                   return (
                     <div 
@@ -1073,22 +1103,19 @@ export default function TransactionsPage() {
                             {transaction.type === 'TRANSFER' && (transaction.transfer_type === 'TRANSFER_IN' || transaction.transfer_type === 'TRANSFER_OUT') ? (
                               <>
                                 <p className="font-semibold">
-                                  {transaction.original_price_per_btc > 0 
-                                    ? formatCurrency(transaction.btc_amount * transaction.original_price_per_btc, transaction.original_currency)
-                                    : formatCurrency(currentValue, transaction.main_currency)
-                                  }
+                                  {formatCurrency(currentValue, displayCurrency)}
                                 </p>
                                 {transaction.original_price_per_btc > 0 && (
-                                  <p className="text-xs text-muted-foreground">Now: {formatCurrency(currentValue, transaction.main_currency)}</p>
+                                  <p className="text-xs text-muted-foreground">Now: {formatCurrency(currentValue, displayCurrency)}</p>
                                 )}
                               </>
                             ) : transaction.type === 'TRANSFER' ? (
                               <span className="text-muted-foreground">—</span>
                             ) : (
                               <>
-                                <p className="font-semibold">{formatCurrency(transaction.main_currency_total_amount, transaction.main_currency)}</p>
+                                <p className="font-semibold">{formatCurrency(totalAmount, displayCurrency)}</p>
                                 {transaction.type === 'BUY' && (
-                                  <p className="text-xs text-muted-foreground">Now: {formatCurrency(currentValue, transaction.main_currency)}</p>
+                                  <p className="text-xs text-muted-foreground">Now: {formatCurrency(currentValue, displayCurrency)}</p>
                                 )}
                               </>
                             )}
@@ -1101,7 +1128,7 @@ export default function TransactionsPage() {
                             ) : (
                               <div>
                                 <p className={cn("font-bold", pnl >= 0 ? 'text-profit' : 'text-loss')}>
-                                  {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, transaction.main_currency)}
+                                  {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, displayCurrency)}
                                 </p>
                                 <p className={cn("text-xs font-medium", pnl >= 0 ? 'text-profit' : 'text-loss')}>
                                   {formatPercentage(pnlPercent)}
@@ -1185,7 +1212,7 @@ export default function TransactionsPage() {
                           </div>
                           <div className="text-right">
                             <p className="font-mono font-semibold">{transaction.btc_amount.toFixed(6)} BTC</p>
-                            <p className="text-sm text-muted-foreground">{formatCurrency(transaction.main_currency_total_amount, transaction.main_currency)}</p>
+                            <p className="text-sm text-muted-foreground">{formatCurrency(totalAmount, displayCurrency)}</p>
                           </div>
                         </div>
                         {(transaction.type === 'BUY' || transaction.type === 'SELL') && (
@@ -1193,7 +1220,7 @@ export default function TransactionsPage() {
                             <p className="text-sm text-muted-foreground">P&L</p>
                             <div className="text-right">
                               <p className={cn("font-bold", pnl >= 0 ? 'text-profit' : 'text-loss')}>
-                                {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, transaction.main_currency)}
+                                {pnl >= 0 ? '+' : ''}{formatCurrency(pnl, displayCurrency)}
                               </p>
                               <p className={cn("text-xs", pnl >= 0 ? 'text-profit' : 'text-loss')}>
                                 {formatPercentage(pnlPercent)}


### PR DESCRIPTION
## Summary

Closes #181

Both pages formatted all monetary values with `mainCurrency` (USD). They now read `secondaryCurrency` and the exchange rate on load and apply it to all displayed amounts.

## Changes

| File | Change |
|------|--------|
| `app/analytics/page.tsx` | Load `secondaryCurrency` + exchange rate from portfolio-metrics and exchange-rates APIs; apply conversion to all formatted values via helper `fc()` |
| `app/transactions/page.tsx` | Same pattern |

## Test plan

- [ ] Set display currency to EUR in Settings
- [ ] Open `/analytics` — all portfolio metrics (P&L, invested, value) show EUR
- [ ] Open `/transactions` — transaction amounts and values show EUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)