### PR TITLE
Fix: Dashboard BTC price header shows USD and wrong 24h sign

### DIFF
--- a/src/components/BitcoinChart.tsx
+++ b/src/components/BitcoinChart.tsx
@@ -21,6 +21,7 @@ import {
 } from 'recharts';
 import { TrendingUpIcon, TrendingDownIcon, ActivityIcon } from 'lucide-react';
 import { BitcoinPriceClient } from '@/lib/bitcoin-price-client';
+import { formatCurrency } from '@/lib/theme';
 import { cn } from '@/lib/utils';
 
 interface BitcoinChartProps {
@@ -69,6 +70,8 @@ export default function BitcoinChart({ height = 400, showTitle = true, showTrans
   const [avgBuyPrice, setAvgBuyPrice] = useState<number>(0);
   const [currentPriceMain, setCurrentPriceMain] = useState<number>(0); // BTC price in user's main currency
   const [mainCurrency, setMainCurrency] = useState<string>('USD');
+  const [secondaryCurrency, setSecondaryCurrency] = useState<string>('');
+  const [mainToSecondaryRate, setMainToSecondaryRate] = useState<number>(1);
   const [transactions, setTransactions] = useState<any[]>([]);
 
   // Load current price and subscribe to updates
@@ -111,6 +114,12 @@ export default function BitcoinChart({ height = 400, showTitle = true, showTrans
           }
           if (result.data.mainCurrency) {
             setMainCurrency(result.data.mainCurrency);
+          }
+          if (result.data.secondaryCurrency) {
+            setSecondaryCurrency(result.data.secondaryCurrency);
+          }
+          if (result.data.mainToSecondaryRate) {
+            setMainToSecondaryRate(result.data.mainToSecondaryRate);
           }
       }
     } catch (error) {
@@ -389,7 +398,7 @@ export default function BitcoinChart({ height = 400, showTitle = true, showTrans
               </div>
               <div className="flex items-baseline gap-2 flex-wrap">
                 <span className="text-2xl font-bold">
-                  ${currentPrice.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                  {formatCurrency(currentPriceMain * mainToSecondaryRate, secondaryCurrency || mainCurrency)}
                 </span>
                 <Badge variant={isPositive ? "default" : "destructive"} className="gap-1 shrink-0">
                   {isPositive ? <TrendingUpIcon className="size-3" /> : <TrendingDownIcon className="size-3" />}
@@ -397,7 +406,7 @@ export default function BitcoinChart({ height = 400, showTitle = true, showTrans
                 </Badge>
                 </div>
               <p className="text-xs text-muted-foreground">
-                {isPositive ? '+' : ''}${Math.abs(priceChange24h).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })} (24h)
+                {isPositive ? '+' : '-'}{formatCurrency(Math.abs(priceChange24h) * (currentPrice > 0 ? currentPriceMain / currentPrice : 1) * mainToSecondaryRate, secondaryCurrency || mainCurrency)} (24h)
               </p>
               </div>
             </div>


### PR DESCRIPTION
Closes #178

## Summary

- BTC price in the chart header now uses the user's configured display (secondary) currency instead of hardcoding USD
- Fixes wrong sign on 24h price change: negative change was shown as `+378 EUR` instead of `-378 EUR` because `formatCurrency()` always returns absolute values — the sign must be prepended explicitly

## Changes

- `src/components/BitcoinChart.tsx`: fetch `secondaryCurrency` and `mainToSecondaryRate` from portfolio-metrics API, convert price and 24h change before display, fix sign logic

## Test plan

- [ ] Open dashboard with a non-USD display currency configured
- [ ] Verify BTC price header shows price in configured currency (e.g. EUR)
- [ ] With a price drop: verify 24h change shows `-378 EUR` (red, minus sign) not `+378 EUR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)