### PR TITLE
feat: persistent API keys for automation

### DIFF
--- a/prisma/migrations/20260222000000_add_api_keys/migration.sql
+++ b/prisma/migrations/20260222000000_add_api_keys/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "api_keys" (
+  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "user_id" INTEGER NOT NULL,
+  "key_hash" TEXT NOT NULL UNIQUE,
+  "key_prefix" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" DATETIME,
+  "last_used_at" DATETIME,
+  CONSTRAINT "api_keys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "api_keys_user_id_idx" ON "api_keys"("user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,8 +127,25 @@ model User {
   goals                 Goal[]
   dashboardLayout       DashboardLayout?
   recurringTransactions RecurringTransaction[]
+  apiKeys               ApiKey[]
 
   @@map("users")
+}
+
+model ApiKey {
+  id         Int       @id @default(autoincrement())
+  userId     Int       @map("user_id")
+  keyHash    String    @unique @map("key_hash")
+  keyPrefix  String    @map("key_prefix")
+  label      String
+  isActive   Boolean   @default(true) @map("is_active")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  expiresAt  DateTime? @map("expires_at")
+  lastUsedAt DateTime? @map("last_used_at")
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("api_keys")
 }
 
 // Custom currencies table for user-defined currencies

--- a/src/app/api/user/api-keys/[id]/route.ts
+++ b/src/app/api/user/api-keys/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireApiAuth } from '@/lib/auth-helpers'
+import { prisma } from '@/lib/prisma'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireApiAuth(request)
+  if ('error' in authResult) {
+    return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status })
+  }
+
+  // Only allow session-based auth (not API keys) for key management
+  const authHeader = request.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer btct_')) {
+    return NextResponse.json(
+      { success: false, error: 'API key management requires session authentication' },
+      { status: 403 }
+    )
+  }
+
+  const userId = parseInt(authResult.user.id)
+  const { id } = await params
+  const keyId = parseInt(id)
+
+  if (isNaN(keyId)) {
+    return NextResponse.json({ success: false, error: 'Invalid key ID' }, { status: 400 })
+  }
+
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { id: keyId }
+  })
+
+  if (!apiKey || apiKey.userId !== userId) {
+    return NextResponse.json({ success: false, error: 'API key not found' }, { status: 404 })
+  }
+
+  await prisma.apiKey.update({
+    where: { id: keyId },
+    data: { isActive: false }
+  })
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/user/api-keys/route.ts
+++ b/src/app/api/user/api-keys/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import { requireApiAuth } from '@/lib/auth-helpers'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(request: NextRequest) {
+  const authResult = await requireApiAuth(request)
+  if ('error' in authResult) {
+    return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status })
+  }
+
+  // Only allow session-based auth (not API keys) for key management
+  const authHeader = request.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer btct_')) {
+    return NextResponse.json(
+      { success: false, error: 'API key management requires session authentication' },
+      { status: 403 }
+    )
+  }
+
+  const userId = parseInt(authResult.user.id)
+
+  const keys = await prisma.apiKey.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      keyPrefix: true,
+      label: true,
+      isActive: true,
+      createdAt: true,
+      expiresAt: true,
+      lastUsedAt: true
+    },
+    orderBy: { createdAt: 'desc' }
+  })
+
+  return NextResponse.json({ success: true, data: keys })
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await requireApiAuth(request)
+  if ('error' in authResult) {
+    return NextResponse.json({ success: false, error: authResult.error }, { status: authResult.status })
+  }
+
+  // Only allow session-based auth (not API keys) for key management
+  const authHeader = request.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer btct_')) {
+    return NextResponse.json(
+      { success: false, error: 'API key management requires session authentication' },
+      { status: 403 }
+    )
+  }
+
+  const userId = parseInt(authResult.user.id)
+
+  let body: { label?: string; expiresIn?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const { label, expiresIn } = body
+
+  if (!label || typeof label !== 'string' || label.trim().length === 0) {
+    return NextResponse.json({ success: false, error: 'Label is required' }, { status: 400 })
+  }
+
+  if (label.trim().length > 100) {
+    return NextResponse.json({ success: false, error: 'Label must be 100 characters or less' }, { status: 400 })
+  }
+
+  // Calculate expiry
+  let expiresAt: Date | null = null
+  if (expiresIn && expiresIn !== 'never') {
+    const now = new Date()
+    switch (expiresIn) {
+      case '30d':
+        expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
+        break
+      case '90d':
+        expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000)
+        break
+      case '1y':
+        expiresAt = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000)
+        break
+      default:
+        return NextResponse.json({ success: false, error: 'Invalid expiresIn value' }, { status: 400 })
+    }
+  }
+
+  // Generate key
+  const raw = crypto.randomBytes(32).toString('hex')
+  const key = `btct_${raw}`
+  const keyHash = crypto.createHash('sha256').update(key).digest('hex')
+  const keyPrefix = raw.slice(0, 8)
+
+  const apiKey = await prisma.apiKey.create({
+    data: {
+      userId,
+      keyHash,
+      keyPrefix,
+      label: label.trim(),
+      isActive: true,
+      expiresAt
+    }
+  })
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      id: apiKey.id,
+      key,
+      keyPrefix,
+      label: apiKey.label,
+      isActive: apiKey.isActive,
+      createdAt: apiKey.createdAt,
+      expiresAt: apiKey.expiresAt,
+      lastUsedAt: apiKey.lastUsedAt
+    }
+  }, { status: 201 })
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -34,10 +34,39 @@ import {
   FlameIcon,
   ArrowLeftRightIcon,
   EditIcon,
+  PlusIcon,
+  CopyIcon,
 } from 'lucide-react';
+
+// Dialog for modals
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 // 2FA Component
 import TwoFactorSetup from '@/components/TwoFactorSetup';
+
+interface ApiKey {
+  id: number;
+  keyPrefix: string;
+  label: string;
+  isActive: boolean;
+  createdAt: string;
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+}
 
 interface UserStats {
   memberSince: string;
@@ -77,6 +106,17 @@ export default function ProfilePage() {
   // 2FA state
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
 
+  // API Keys state
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [apiKeysLoading, setApiKeysLoading] = useState(false);
+  const [showGenerateModal, setShowGenerateModal] = useState(false);
+  const [newKeyLabel, setNewKeyLabel] = useState('');
+  const [newKeyExpiry, setNewKeyExpiry] = useState('never');
+  const [generatingKey, setGeneratingKey] = useState(false);
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [keyCopied, setKeyCopied] = useState(false);
+  const [apiKeyError, setApiKeyError] = useState('');
+
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/auth/signin');
@@ -84,6 +124,7 @@ export default function ProfilePage() {
       loadUserStats();
       loadUserData();
       load2FAStatus();
+      loadApiKeys();
     }
   }, [status, router]);
 
@@ -97,6 +138,82 @@ export default function ProfilePage() {
     } catch (error) {
       console.error('Error loading 2FA status:', error);
     }
+  };
+
+  const loadApiKeys = async () => {
+    setApiKeysLoading(true);
+    try {
+      const response = await fetch('/api/user/api-keys');
+      if (response.ok) {
+        const result = await response.json();
+        if (result.success) {
+          setApiKeys(result.data);
+        }
+      }
+    } catch (error) {
+      console.error('Error loading API keys:', error);
+    } finally {
+      setApiKeysLoading(false);
+    }
+  };
+
+  const handleGenerateKey = async () => {
+    if (!newKeyLabel.trim()) {
+      setApiKeyError('Label is required');
+      return;
+    }
+    setApiKeyError('');
+    setGeneratingKey(true);
+    try {
+      const response = await fetch('/api/user/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: newKeyLabel.trim(), expiresIn: newKeyExpiry })
+      });
+      const result = await response.json();
+      if (response.ok && result.success) {
+        setGeneratedKey(result.data.key);
+        await loadApiKeys();
+      } else {
+        setApiKeyError(result.error || 'Failed to generate key');
+      }
+    } catch (error) {
+      setApiKeyError('An error occurred while generating key');
+    } finally {
+      setGeneratingKey(false);
+    }
+  };
+
+  const handleRevokeKey = async (id: number) => {
+    if (!confirm('Are you sure you want to revoke this API key? This cannot be undone.')) return;
+    try {
+      const response = await fetch(`/api/user/api-keys/${id}`, { method: 'DELETE' });
+      if (response.ok) {
+        await loadApiKeys();
+      }
+    } catch (error) {
+      console.error('Error revoking API key:', error);
+    }
+  };
+
+  const handleCopyKey = async () => {
+    if (!generatedKey) return;
+    try {
+      await navigator.clipboard.writeText(generatedKey);
+      setKeyCopied(true);
+      setTimeout(() => setKeyCopied(false), 2000);
+    } catch {
+      // fallback: select text
+    }
+  };
+
+  const handleCloseGenerateModal = () => {
+    setShowGenerateModal(false);
+    setNewKeyLabel('');
+    setNewKeyExpiry('never');
+    setGeneratedKey(null);
+    setKeyCopied(false);
+    setApiKeyError('');
   };
 
   const loadUserStats = async () => {
@@ -680,6 +797,82 @@ export default function ProfilePage() {
             onStatusChange={load2FAStatus}
           />
 
+          {/* API Keys */}
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <KeyIcon className="size-5" />
+                    API Keys
+                  </CardTitle>
+                  <CardDescription>Manage API keys for automation integrations (n8n, scripts, etc.)</CardDescription>
+                </div>
+                <Button size="sm" onClick={() => setShowGenerateModal(true)}>
+                  <PlusIcon className="size-4 mr-1" />
+                  Generate New Key
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {apiKeysLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="size-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : apiKeys.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <KeyIcon className="size-8 mx-auto mb-2 opacity-40" />
+                  <p className="text-sm">No API keys yet. Generate one to automate transactions.</p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {apiKeys.map((key) => (
+                    <div
+                      key={key.id}
+                      className={cn(
+                        'flex items-center justify-between p-3 rounded-lg border',
+                        key.isActive ? 'bg-muted/30' : 'bg-muted/10 opacity-60'
+                      )}
+                    >
+                      <div className="flex-1 min-w-0 space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm truncate">{key.label}</span>
+                          {!key.isActive && (
+                            <Badge variant="secondary" className="text-xs">Revoked</Badge>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
+                          <span className="font-mono">btct_{key.keyPrefix}…</span>
+                          <span>Created {new Date(key.createdAt).toLocaleDateString()}</span>
+                          {key.lastUsedAt && (
+                            <span>Last used {new Date(key.lastUsedAt).toLocaleDateString()}</span>
+                          )}
+                          {key.expiresAt && (
+                            <span>
+                              {new Date(key.expiresAt) < new Date()
+                                ? 'Expired'
+                                : `Expires ${new Date(key.expiresAt).toLocaleDateString()}`}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {key.isActive && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive hover:bg-destructive/10 ml-2 shrink-0"
+                          onClick={() => handleRevokeKey(key.id)}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
           {/* Data & Session */}
           <Card>
             <CardHeader>
@@ -740,6 +933,95 @@ export default function ProfilePage() {
           </Card>
         </div>
       </div>
+
+      {/* Generate API Key Modal */}
+      <Dialog open={showGenerateModal} onOpenChange={(open) => { if (!open) handleCloseGenerateModal(); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Generate API Key</DialogTitle>
+            <DialogDescription>
+              Create a new API key for automation integrations.
+            </DialogDescription>
+          </DialogHeader>
+
+          {generatedKey ? (
+            <div className="space-y-4">
+              <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg text-amber-700 dark:text-amber-400 text-sm flex gap-2">
+                <AlertCircleIcon className="size-4 shrink-0 mt-0.5" />
+                <span>Save this key now — it will not be shown again.</span>
+              </div>
+              <div className="space-y-1">
+                <Label>Your new API key</Label>
+                <div className="flex gap-2">
+                  <Input
+                    readOnly
+                    value={generatedKey}
+                    className="font-mono text-xs"
+                    onClick={(e) => (e.target as HTMLInputElement).select()}
+                  />
+                  <Button variant="outline" size="icon" onClick={handleCopyKey}>
+                    {keyCopied ? <CheckIcon className="size-4 text-profit" /> : <CopyIcon className="size-4" />}
+                  </Button>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Use this key as a Bearer token: <code className="bg-muted px-1 rounded">Authorization: Bearer {generatedKey.slice(0, 16)}…</code>
+              </p>
+              <DialogFooter>
+                <Button onClick={handleCloseGenerateModal} className="w-full">Done</Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="keyLabel">Label</Label>
+                <Input
+                  id="keyLabel"
+                  placeholder="e.g. n8n automation, home server"
+                  value={newKeyLabel}
+                  onChange={(e) => setNewKeyLabel(e.target.value)}
+                  maxLength={100}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="keyExpiry">Expiry</Label>
+                <Select value={newKeyExpiry} onValueChange={setNewKeyExpiry}>
+                  <SelectTrigger id="keyExpiry">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="never">Never</SelectItem>
+                    <SelectItem value="30d">30 days</SelectItem>
+                    <SelectItem value="90d">90 days</SelectItem>
+                    <SelectItem value="1y">1 year</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {apiKeyError && (
+                <div className="flex items-center gap-2 p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm">
+                  <AlertCircleIcon className="size-4" />
+                  {apiKeyError}
+                </div>
+              )}
+
+              <DialogFooter className="gap-2">
+                <Button variant="outline" onClick={handleCloseGenerateModal}>Cancel</Button>
+                <Button onClick={handleGenerateKey} disabled={generatingKey}>
+                  {generatingKey ? (
+                    <span className="flex items-center gap-2">
+                      <div className="size-4 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" />
+                      Generating…
+                    </span>
+                  ) : (
+                    'Generate Key'
+                  )}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </AppLayout>
   );
 }

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { jwtVerify } from 'jose'
+import crypto from 'crypto'
 
 export interface AuthUser {
   id: string
@@ -57,20 +58,67 @@ export async function getAuthToken(request: NextRequest) {
  */
 export async function verifyApiToken(request: NextRequest): Promise<AuthUser | null> {
   try {
+    const { prisma } = await import('@/lib/prisma')
+
+    // Check for API key (btct_ prefix) before trying JWT
+    const bearerToken = extractBearerToken(request)
+    if (bearerToken?.startsWith('btct_')) {
+      const keyHash = crypto.createHash('sha256').update(bearerToken).digest('hex')
+      const apiKey = await prisma.apiKey.findUnique({
+        where: { keyHash },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              name: true,
+              isAdmin: true,
+              isActive: true
+            }
+          }
+        }
+      })
+
+      if (!apiKey || !apiKey.isActive) {
+        return null
+      }
+
+      if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+        return null
+      }
+
+      if (!apiKey.user.isActive) {
+        return null
+      }
+
+      // Update lastUsedAt asynchronously (fire-and-forget)
+      prisma.apiKey.update({
+        where: { id: apiKey.id },
+        data: { lastUsedAt: new Date() }
+      }).catch(() => {})
+
+      return {
+        id: apiKey.user.id.toString(),
+        email: apiKey.user.email,
+        name: apiKey.user.name || undefined,
+        isAdmin: apiKey.user.isAdmin,
+        isActive: apiKey.user.isActive
+      }
+    }
+
     const token = await getAuthToken(request)
-    
+
     if (!token?.sub || !token?.email) {
       return null
     }
-    
+
     // Check token expiration
     if (token.exp && typeof token.exp === 'number' && Date.now() >= token.exp * 1000) {
       console.log('Token expired')
       return null
     }
-    
+
     // Get fresh user data from database to include admin status
-    const { prisma } = await import('@/lib/prisma')
     const user = await prisma.user.findUnique({
       where: { id: parseInt(token.sub) },
       select: {
@@ -81,11 +129,11 @@ export async function verifyApiToken(request: NextRequest): Promise<AuthUser | n
         isActive: true
       }
     })
-    
+
     if (!user || !user.isActive) {
       return null
     }
-    
+
     return {
       id: user.id.toString(),
       email: user.email,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,11 +16,16 @@ const middleware = withAuth(
         
         if (isApiRoute && authHeader?.startsWith('Bearer ')) {
           const bearerToken = authHeader.substring(7)
-          
+
+          // API key format — pass through; route handler validates
+          if (bearerToken.startsWith('btct_')) {
+            return true
+          }
+
           try {
             // Verify JWT token using NextAuth's secret
             const { payload } = await jwtVerify(bearerToken, secret)
-            
+
             // Check if token has required claims
             if (payload.sub && payload.email) {
               return true
@@ -50,6 +55,8 @@ export const config = {
     '/settings',
     '/api/transactions/:path*',
     '/api/settings/:path*',
-    '/api/historical-data/:path*'
+    '/api/historical-data/:path*',
+    '/api/analytics/:path*',
+    '/api/portfolio-metrics'
   ]
 } 


### PR DESCRIPTION
Closes #158

## Summary
- Add `ApiKey` model + migration (`api_keys` table, SHA-256 hash stored, never the raw key)
- `btct_<32-hex>` tokens pass through middleware; validated in `verifyApiToken()` via hash lookup
- `GET/POST /api/user/api-keys` — list & generate keys (session-auth only)
- `DELETE /api/user/api-keys/[id]` — revoke a key
- Profile page: API Keys card with table, revoke button, generate modal with one-time key display

## Test plan
- [ ] Generate key via Profile → copy key
- [ ] `curl -H "Authorization: Bearer btct_xxx" /api/transactions` → returns data
- [ ] `curl -X POST ... /api/transactions` with key → creates transaction
- [ ] Revoke key → same curl returns 401
- [ ] Docker build + run — migration creates `api_keys` table