### PR TITLE
feat: add River CSV import parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 - **Multiple named wallets** — create and manage multiple hot/cold wallets with custom names; wallets are selectable when recording transfers and displayed with per-wallet BTC balances in the Wallet Distribution widget and portfolio metrics ([#193](https://github.com/wilqq-the/BTC-Tracker/pull/193))
+- **River CSV import** — supports Buy transactions, zero-cost Interest rows (BTC earned on cash held at River), and external Receive transfers (BTC sent in from another wallet) ([#160](https://github.com/wilqq-the/BTC-Tracker/issues/160))
 - **Strike CSV import** now supports both the older Format A (`Transaction ID`, `Time (UTC)`, `Status`, `Exchange Rate`) and the newer Format B (`Reference`, `Date & Time (UTC)`, `BTC Price`, `Cost Basis`) export layouts, with automatic format detection ([#169](https://github.com/wilqq-the/BTC-Tracker/pull/169))
 - **REST API documentation** added for automation and n8n integration use cases ([#187](https://github.com/wilqq-the/BTC-Tracker/pull/187))
 - **Persistent tokens** added to profile for automation purposes

--- a/src/app/api/transactions/import/parsers/index.ts
+++ b/src/app/api/transactions/import/parsers/index.ts
@@ -8,6 +8,7 @@ import { BinanceParser } from './binance';
 import { CoinbaseParser } from './coinbase';
 import { StrikeParser } from './strike';
 import { Bitcoin21Parser } from './bitcoin21';
+import { RiverParser } from './river';
 import { LegacyParser } from './legacy';
 import { StandardParser } from './standard';
 
@@ -22,6 +23,7 @@ const PARSERS: Parser[] = [
   new CoinbaseParser(),
   new StrikeParser(),
   new Bitcoin21Parser(),
+  new RiverParser(),
   new LegacyParser(),
   new StandardParser(), // Fallback parser - should be last
 ];

--- a/src/app/api/transactions/import/parsers/river.ts
+++ b/src/app/api/transactions/import/parsers/river.ts
@@ -1,0 +1,131 @@
+/**
+ * River exchange CSV parser
+ *
+ * CSV Format:
+ * Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+ *
+ * Transaction types (determined by Tag column):
+ * - "Buy"      : regular BTC purchase (Sent = fiat, Received = BTC)
+ * - "Interest" : zero-cost BTC earned as interest on cash held at River
+ * - ""          : BTC received from an external wallet (Transfer In)
+ */
+
+import { BaseParser } from './base';
+import { ImportTransaction } from './types';
+
+export class RiverParser extends BaseParser {
+  name = 'river';
+
+  private readonly requiredHeaders = [
+    'date',
+    'sent amount',
+    'sent currency',
+    'received amount',
+    'received currency',
+    'fee amount',
+    'fee currency',
+    'tag',
+  ];
+
+  canParse(headers: string[]): boolean {
+    const lc = headers.map(h => h.toLowerCase().trim());
+    const matchCount = this.requiredHeaders.filter(h => lc.includes(h)).length;
+    return matchCount >= 6;
+  }
+
+  getConfidenceScore(headers: string[]): number {
+    const lc = headers.map(h => h.toLowerCase().trim());
+    const matchCount = this.requiredHeaders.filter(h => lc.includes(h)).length;
+    return (matchCount / this.requiredHeaders.length) * 100;
+  }
+
+  parseTransaction(
+    transaction: any,
+    _headers: string[],
+    _values: string[]
+  ): ImportTransaction | null {
+    const tag = (transaction['tag'] || '').trim().toLowerCase();
+    const receivedCurrency = (transaction['received currency'] || '').trim().toUpperCase();
+    const sentCurrency = (transaction['sent currency'] || '').trim().toUpperCase();
+    const receivedAmount = this.parseFloat(transaction['received amount']);
+    const sentAmount = this.parseFloat(transaction['sent amount']);
+    const feeAmount = this.parseFloat(transaction['fee amount']);
+    const feeCurrency = (transaction['fee currency'] || sentCurrency || 'USD').trim().toUpperCase();
+    const transactionDate = this.parseDate(transaction['date'] || '');
+
+    // Only process rows where BTC is received
+    if (receivedCurrency !== 'BTC' || receivedAmount <= 0) {
+      return null;
+    }
+
+    // --- Buy ---
+    if (tag === 'buy') {
+      const currency = sentCurrency || 'USD';
+      const pricePerBtc = receivedAmount > 0 ? sentAmount / receivedAmount : 0;
+
+      const result: ImportTransaction = {
+        type: 'BUY',
+        btc_amount: receivedAmount,
+        original_price_per_btc: pricePerBtc,
+        original_currency: currency,
+        original_total_amount: sentAmount,
+        fees: feeAmount,
+        fees_currency: feeAmount > 0 ? feeCurrency : currency,
+        transaction_date: transactionDate,
+        notes: 'River Buy',
+      };
+
+      try {
+        return this.validateTransaction(result);
+      } catch {
+        return null;
+      }
+    }
+
+    // --- Interest (zero-cost BTC earned on cash held at River) ---
+    if (tag === 'interest') {
+      const result: ImportTransaction = {
+        type: 'BUY',
+        btc_amount: receivedAmount,
+        original_price_per_btc: 0,
+        original_currency: 'USD',
+        original_total_amount: 0,
+        fees: 0,
+        fees_currency: 'USD',
+        transaction_date: transactionDate,
+        notes: 'River Interest',
+      };
+
+      try {
+        return this.validateTransaction(result);
+      } catch {
+        return null;
+      }
+    }
+
+    // --- Transfer In (empty tag = BTC received from an external wallet) ---
+    if (tag === '' && sentAmount === 0) {
+      const result: ImportTransaction = {
+        type: 'TRANSFER',
+        btc_amount: receivedAmount,
+        original_price_per_btc: 0,
+        original_currency: 'USD',
+        original_total_amount: 0,
+        fees: 0,
+        fees_currency: 'USD',
+        transaction_date: transactionDate,
+        notes: 'River Receive',
+        transfer_type: 'FROM_COLD_WALLET',
+        destination_address: null,
+      };
+
+      try {
+        return this.validateTransaction(result);
+      } catch {
+        return null;
+      }
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #160

## Summary

Adds a new `RiverParser` for importing CSV exports from [River](https://river.com) (Taxes & Documents → Generate custom report).

## CSV format

```
Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
```

## Supported row types

| Tag | Description | Imported as |
|---|---|---|
| `Buy` | Regular BTC purchase | `BUY` — price derived from Sent/Received amounts, fee included |
| `Interest` | Zero-cost BTC earned on cash held at River | `BUY` — zero price/total (same handling as mining/gifts) |
| *(empty)* | BTC received from an external wallet | `TRANSFER` / `FROM_COLD_WALLET` |

## Test plan

- [x] Import the sample CSV from issue #160 — all 26 rows parse correctly (23 Buys, 2 Interest, 1 Receive)
- [x] Verify Buy prices match `Sent Amount / Received Amount`
- [x] Verify Interest rows show zero cost basis
- [x] Verify the empty-tag Receive row appears as a Transfer In
- [x] Confirm auto-detection selects the River parser (not the standard fallback)