### PR TITLE
fix: restore and fix 36 skipped tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
   coverageReporters: ['text', 'lcov', 'html'],
   setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
   testTimeout: 10000,
+  // All test files share the same SQLite test database — run serially to
+  // prevent concurrent cleanTestDatabase() calls from causing FK violations.
+  maxWorkers: 1,
   clearMocks: true,
   restoreMocks: true,
   setupFiles: ['<rootDir>/src/tests/jest.env.js']

--- a/src/tests/api/settings.test.ts
+++ b/src/tests/api/settings.test.ts
@@ -104,7 +104,7 @@ describe('Settings API', () => {
       expect(data.data.display.theme).toBe('dark') // Should be back to default
     })
 
-    it.skip('should maintain settings ID when resetting', async () => {
+    it('should maintain settings ID when resetting', async () => {
       const initialResponse = await settingsGET()
       const initialData = await initialResponse.json()
       const initialId = initialData.data.id

--- a/src/tests/api/transactions.test.ts
+++ b/src/tests/api/transactions.test.ts
@@ -54,7 +54,7 @@ const createMockRequest = (method: string, url: string, body?: any, headers?: an
 import { GET as transactionsGET, POST as transactionsPOST } from '../../app/api/transactions/route'
 import { GET as transactionGET, PUT as transactionPUT, DELETE as transactionDELETE } from '../../app/api/transactions/[id]/route'
 
-describe.skip('Transactions API', () => {
+describe('Transactions API', () => {
   let testUser: any
   let testToken: string
   let authHeaders: { Authorization: string }
@@ -474,7 +474,7 @@ describe.skip('Transactions API', () => {
       expect(response.status).toBe(400)
       expect(data.success).toBe(false)
       expect(data.error).toBe('Invalid numeric values')
-      expect(data.message).toContain('positive numbers')
+      expect(data.message).toContain('BTC amount must be positive')
     })
 
     it('should fail with non-numeric string values', async () => {
@@ -930,7 +930,7 @@ describe.skip('Transactions API', () => {
   describe('Error Handling', () => {
     it('should handle malformed JSON in POST request', async () => {
       const mockRequest = {
-        method: 'POST',
+        ...createMockRequest('POST', '/api/transactions', null, authHeaders),
         json: async () => { throw new Error('Invalid JSON') }
       } as unknown as NextRequest
 
@@ -939,12 +939,12 @@ describe.skip('Transactions API', () => {
 
       expect(response.status).toBe(500)
       expect(data.success).toBe(false)
-      expect(data.error).toBe('Failed to create transaction')
+      expect(data.error).toBe('Internal server error')
     })
 
     it('should handle malformed JSON in PUT request', async () => {
       const mockRequest = {
-        method: 'PUT',
+        ...createMockRequest('PUT', `/api/transactions/${testTransactionId}`, null, authHeaders),
         json: async () => { throw new Error('Invalid JSON') }
       } as unknown as NextRequest
       const context = { params: Promise.resolve({ id: testTransactionId.toString() }) }
@@ -954,7 +954,7 @@ describe.skip('Transactions API', () => {
 
       expect(response.status).toBe(500)
       expect(data.success).toBe(false)
-      expect(data.error).toBe('Failed to update transaction')
+      expect(data.error).toBe('Internal server error')
     })
   })
 }) 

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -112,18 +112,21 @@ export const createTestTransactionData = (overrides: any = {}) => {
  * Create test transaction in database
  */
 export async function createTestTransaction(transactionData: any = {}) {
-  // Remove userId and date fields that don't belong in the Prisma model
+  // Extract userId and date separately — userId must be forwarded to Prisma
   const { userId, date, ...cleanData } = transactionData
-  
+
   // Use date for transactionDate if provided
   if (date && !cleanData.transactionDate) {
     cleanData.transactionDate = date
   }
-  
+
   const testData = createTestTransactionData(cleanData)
-  
+
   return await testDb.bitcoinTransaction.create({
-    data: testData
+    data: {
+      ...testData,
+      ...(userId !== undefined ? { userId } : {})
+    }
   })
 }
 


### PR DESCRIPTION
## Summary

- **`test-helpers.ts`**: Fixed `createTestTransaction` stripping `userId` before passing data to Prisma — PUT/DELETE routes filter by `{ id, userId }` so transactions created without a userId were invisible to them
- **`transactions.test.ts`**: Unskipped the entire `describe` block; fixed two error-handling tests to include auth headers (bare mocks had no `headers` property, causing 401 instead of 500); fixed stale assertion message to match actual route output
- **`settings.test.ts`**: Unskipped ID-stability test — `seedTestDatabase` always upserts at `id=1` so the original autoincrement concern doesn't apply
- **`jest.config.js`**: Added `maxWorkers: 1` to serialize test suite execution and prevent concurrent FK violations on the shared SQLite test database

## Test plan

- [x] All 242 tests pass (`npm test`)
- [x] 0 skipped tests remain
- [x] No changes to application code — test infrastructure only