### PR TITLE
feat(backup): full-database backup & restore (admin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ CLAUDE.md
 # Uploaded files
 data/uploads/*
 
+# Backups (snapshots, gzip sidecars, metadata, backup-config.json — db-adjacent)
+**/backups/
+
 # Electron
 /dist-electron

--- a/README.md
+++ b/README.md
@@ -191,17 +191,29 @@ This gives you complete control over your Bitcoin tracking data.
 
 ## Backup & Restore
 
-Your data lives in a single SQLite file. To backup:
+Your data lives in a single SQLite file. The easiest way to manage backups is from the app:
+
+**Settings → Backup** (admin only):
+- **Download backup** — grab a full-database snapshot to your computer
+- **Server snapshots** — create/keep snapshots on the server and download, restore, or delete them
+- **Restore from a file** — upload a backup to replace all data (a safety backup of the current database is taken automatically first)
+- **Automatic backups** — schedule periodic snapshots with retention (keep last N / keep N days)
+
+A backup is the whole database (every user's data), so restoring is admin-only and replaces everything.
+
+> **Note:** Exchange API credentials are encrypted with a key derived from `NEXTAUTH_SECRET`. A backup restored on the **same** install decrypts them fine; restoring onto an install with a **different** `NEXTAUTH_SECRET` leaves those credentials unreadable (all other data is unaffected). After a restore you may need to sign in again.
+
+You can still back up manually by copying the SQLite file:
 
 ```bash
 # Docker
-docker cp btc-tracker:/app/prisma/dev.db ./backup.db
+docker cp btc-tracker:/app/data/bitcoin-tracker.db ./backup.db
 
 # Local
 cp prisma/dev.db ./backup.db
 ```
 
-To restore, copy the file back and restart the app.
+To restore manually, copy the file back and restart the app.
 
 ## Community
 

--- a/src/app/api/backup/[filename]/download/route.ts
+++ b/src/app/api/backup/[filename]/download/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService } from '@/lib/backup-service';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/backup/:filename/download
+ * Stream an existing server-side snapshot to the browser.
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ filename: string }> }) {
+  return withAdminAuth(request, async () => {
+    const { filename } = await params;
+    try {
+      const buffer = await BackupService.readSnapshot(filename);
+      // Node Buffer is a valid body at runtime; cast past the DOM BodyInit type.
+      return new NextResponse(buffer as unknown as BodyInit, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Length': String(buffer.length),
+        },
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      if (/Invalid backup filename/i.test(msg)) {
+        return NextResponse.json({ success: false, error: msg }, { status: 400 });
+      }
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        return NextResponse.json({ success: false, error: 'Backup not found' }, { status: 404 });
+      }
+      console.error('Downloading backup failed:', error);
+      return NextResponse.json({ success: false, error: 'Failed to download backup', message: msg }, { status: 500 });
+    }
+  });
+}

--- a/src/app/api/backup/[filename]/route.ts
+++ b/src/app/api/backup/[filename]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService } from '@/lib/backup-service';
+
+export const runtime = 'nodejs';
+
+/**
+ * DELETE /api/backup/:filename
+ * Delete a server-side snapshot and its metadata sidecar.
+ */
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ filename: string }> }) {
+  return withAdminAuth(request, async () => {
+    const { filename } = await params;
+    try {
+      await BackupService.deleteSnapshot(filename);
+      return NextResponse.json({ success: true, message: 'Backup deleted' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      if (/Invalid backup filename/i.test(msg)) {
+        return NextResponse.json({ success: false, error: msg }, { status: 400 });
+      }
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        return NextResponse.json({ success: false, error: 'Backup not found' }, { status: 404 });
+      }
+      console.error('Deleting backup failed:', error);
+      return NextResponse.json({ success: false, error: 'Failed to delete backup', message: msg }, { status: 500 });
+    }
+  });
+}

--- a/src/app/api/backup/export/route.ts
+++ b/src/app/api/backup/export/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService } from '@/lib/backup-service';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/backup/export
+ * Create a fresh full-database snapshot on the fly and stream it to the browser.
+ * The snapshot is NOT retained server-side (use POST /api/backup for that).
+ * Query: ?gzip=true to gzip the download.
+ */
+export async function GET(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    try {
+      const gzip = new URL(request.url).searchParams.get('gzip') === 'true';
+      const meta = await BackupService.createSnapshot({ kind: 'manual', gzip });
+      const buffer = await BackupService.readSnapshot(meta.filename);
+      // On-the-fly export: remove the server copy after reading it into memory.
+      await BackupService.deleteSnapshot(meta.filename).catch(() => {});
+
+      // Node Buffer is a valid body at runtime; cast past the DOM BodyInit type.
+      return new NextResponse(buffer as unknown as BodyInit, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': `attachment; filename="${meta.filename}"`,
+          'Content-Length': String(buffer.length),
+        },
+      });
+    } catch (error) {
+      console.error('Backup export failed:', error);
+      return NextResponse.json(
+        { success: false, error: 'Backup export failed', message: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  });
+}

--- a/src/app/api/backup/restore/route.ts
+++ b/src/app/api/backup/restore/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService } from '@/lib/backup-service';
+
+export const runtime = 'nodejs';
+
+/**
+ * POST /api/backup/restore  (DESTRUCTIVE — replaces ALL data)
+ * Accepts either:
+ *  - multipart/form-data with a `file` field (uploaded backup), or
+ *  - JSON `{ filename }` to restore an existing server-side snapshot.
+ */
+export async function POST(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    if (BackupService.isRestoreInProgress()) {
+      return NextResponse.json({ success: false, error: 'A restore is already in progress' }, { status: 409 });
+    }
+
+    try {
+      const contentType = request.headers.get('content-type') || '';
+      let result;
+
+      if (contentType.includes('multipart/form-data')) {
+        const form = await request.formData();
+        const file = form.get('file');
+        if (!file || typeof file === 'string') {
+          return NextResponse.json({ success: false, error: 'No backup file provided' }, { status: 400 });
+        }
+        const buffer = Buffer.from(await (file as File).arrayBuffer());
+        result = await BackupService.restoreFromBuffer(buffer, { sourceName: (file as File).name });
+      } else {
+        const body = await request.json().catch(() => ({} as { filename?: string }));
+        if (!body?.filename) {
+          return NextResponse.json({ success: false, error: 'filename is required' }, { status: 400 });
+        }
+        result = await BackupService.restoreFromServerSnapshot(body.filename);
+      }
+
+      return NextResponse.json({ success: true, data: result, message: 'Restore complete' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      if (/RESTORE_IN_PROGRESS/.test(msg)) {
+        return NextResponse.json({ success: false, error: 'A restore is already in progress' }, { status: 409 });
+      }
+      if (/not a SQLite|missing required table|newer app version|Invalid backup filename/i.test(msg)) {
+        return NextResponse.json({ success: false, error: msg }, { status: 400 });
+      }
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        return NextResponse.json({ success: false, error: 'Backup not found' }, { status: 404 });
+      }
+      console.error('Restore failed:', error);
+      return NextResponse.json({ success: false, error: 'Restore failed', message: msg }, { status: 500 });
+    }
+  });
+}

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService } from '@/lib/backup-service';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/backup
+ * List server-side snapshots (newest first).
+ */
+export async function GET(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    try {
+      const data = await BackupService.listSnapshots();
+      return NextResponse.json({ success: true, data });
+    } catch (error) {
+      console.error('Listing backups failed:', error);
+      return NextResponse.json(
+        { success: false, error: 'Failed to list backups', message: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  });
+}
+
+/**
+ * POST /api/backup
+ * Create and retain a server-side snapshot.
+ * Body (optional): { gzip?: boolean, label?: string }
+ */
+export async function POST(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    try {
+      const body = await request.json().catch(() => ({} as { gzip?: boolean; label?: string }));
+      const gzip = typeof body?.gzip === 'boolean' ? body.gzip : (await BackupService.getConfig()).gzip;
+      const meta = await BackupService.createSnapshot({ kind: 'manual', gzip, label: body?.label });
+      return NextResponse.json({ success: true, data: meta, message: 'Backup created' }, { status: 201 });
+    } catch (error) {
+      console.error('Creating backup failed:', error);
+      return NextResponse.json(
+        { success: false, error: 'Failed to create backup', message: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  });
+}

--- a/src/app/api/backup/schedule/route.ts
+++ b/src/app/api/backup/schedule/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { BackupService, BackupConfig } from '@/lib/backup-service';
+import { BackupScheduler } from '@/lib/backup-scheduler';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/backup/schedule
+ * Return the current backup schedule/retention config plus scheduler status.
+ */
+export async function GET(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    try {
+      const config = await BackupService.getConfig();
+      return NextResponse.json({ success: true, data: { config, status: BackupScheduler.getStatus() } });
+    } catch (error) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to load schedule', message: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  });
+}
+
+/**
+ * PUT /api/backup/schedule
+ * Update the schedule/retention config and (re)start the scheduler.
+ * Body: { enabled?, intervalHours?, gzip?, retention?: { keepLast?, keepDays? } }
+ */
+export async function PUT(request: NextRequest) {
+  return withAdminAuth(request, async () => {
+    try {
+      const body = (await request.json().catch(() => ({}))) as Partial<BackupConfig>;
+
+      const updates: Partial<BackupConfig> = {};
+      if (typeof body.enabled === 'boolean') updates.enabled = body.enabled;
+      if (typeof body.gzip === 'boolean') updates.gzip = body.gzip;
+      if (body.intervalHours !== undefined) {
+        const h = Number(body.intervalHours);
+        if (!Number.isFinite(h) || h < 1) {
+          return NextResponse.json({ success: false, error: 'intervalHours must be a number >= 1' }, { status: 400 });
+        }
+        updates.intervalHours = h;
+      }
+      if (body.retention) {
+        updates.retention = {};
+        if (body.retention.keepLast !== undefined && body.retention.keepLast !== null) {
+          const n = Number(body.retention.keepLast);
+          if (!Number.isInteger(n) || n < 0) {
+            return NextResponse.json({ success: false, error: 'retention.keepLast must be a non-negative integer' }, { status: 400 });
+          }
+          updates.retention.keepLast = n;
+        }
+        if (body.retention.keepDays !== undefined && body.retention.keepDays !== null) {
+          const n = Number(body.retention.keepDays);
+          if (!Number.isInteger(n) || n < 0) {
+            return NextResponse.json({ success: false, error: 'retention.keepDays must be a non-negative integer' }, { status: 400 });
+          }
+          updates.retention.keepDays = n;
+        }
+      }
+
+      const config = await BackupService.saveConfig(updates);
+      await BackupScheduler.restart();
+
+      return NextResponse.json({ success: true, data: { config, status: BackupScheduler.getStatus() }, message: 'Schedule updated' });
+    } catch (error) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to update schedule', message: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,15 +4,16 @@ import React, { useState, useEffect } from 'react';
 import { AppSettings } from '@/lib/types';
 import { CurrencySettingsPanel, PriceDataSettingsPanel, DisplaySettingsPanel, NotificationSettingsPanel, UserAccountSettingsPanel } from '@/components/SettingsPanels';
 import AdminPanel from '@/components/AdminPanel';
+import BackupRestorePanel from '@/components/BackupRestorePanel';
 import ExchangeConnectionsPanel from '@/components/ExchangeConnectionsPanel';
 import AppLayout from '@/components/AppLayout';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { SettingsIcon, UserIcon, DollarSignIcon, BarChart3Icon, MonitorIcon, BellIcon, ShieldIcon, ArrowLeftRightIcon } from 'lucide-react';
+import { SettingsIcon, UserIcon, DollarSignIcon, BarChart3Icon, MonitorIcon, BellIcon, ShieldIcon, ArrowLeftRightIcon, DatabaseIcon } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import packageJson from '../../../package.json';
 
-type SettingsTab = 'currency' | 'priceData' | 'display' | 'notifications' | 'account' | 'exchanges' | 'admin';
+type SettingsTab = 'currency' | 'priceData' | 'display' | 'notifications' | 'account' | 'exchanges' | 'admin' | 'backup';
 
 interface SettingsResponse {
   success: boolean;
@@ -136,7 +137,10 @@ export default function SettingsPage() {
     { id: 'priceData', label: 'Price Data', icon: BarChart3Icon },
     { id: 'exchanges', label: 'Exchanges', icon: ArrowLeftRightIcon },
     { id: 'display', label: 'Display', icon: MonitorIcon },
-    ...(userData?.isAdmin ? [{ id: 'admin', label: 'Admin', icon: ShieldIcon }] : [])
+    ...(userData?.isAdmin ? [
+      { id: 'backup', label: 'Backup', icon: DatabaseIcon },
+      { id: 'admin', label: 'Admin', icon: ShieldIcon }
+    ] : [])
   ];
 
   return (
@@ -260,6 +264,10 @@ export default function SettingsPage() {
               onUpdate={(updates: any) => updateSettings('notifications', updates)}
               saving={saving}
             />
+          )}
+
+          {activeTab === 'backup' && userData?.isAdmin && (
+            <BackupRestorePanel />
           )}
 
           {activeTab === 'admin' && userData?.isAdmin && (

--- a/src/components/BackupRestorePanel.tsx
+++ b/src/components/BackupRestorePanel.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from '@/components/ui/dialog';
+import { DatabaseIcon, DownloadIcon, UploadIcon, Trash2Icon, RotateCcwIcon, AlertTriangleIcon, ClockIcon } from 'lucide-react';
+import { toast } from '@/hooks/use-toast';
+
+interface Snapshot {
+  filename: string;
+  sizeBytes: number;
+  createdAt: string;
+  appVersion: string;
+  schemaVersion: string;
+  gzip: boolean;
+  kind: 'manual' | 'scheduled' | 'safety';
+}
+
+interface ScheduleConfig {
+  enabled: boolean;
+  intervalHours: number;
+  gzip: boolean;
+  retention: { keepLast: number | null; keepDays: number | null };
+  lastRunAt: string | null;
+  lastError: string | null;
+}
+
+type RestoreTarget = { type: 'file'; file: File } | { type: 'server'; filename: string } | null;
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+async function downloadFromUrl(url: string, fallbackName: string): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Download failed');
+  const cd = res.headers.get('content-disposition') || '';
+  const match = /filename="?([^"]+)"?/.exec(cd);
+  const name = match ? match[1] : fallbackName;
+  const blob = await res.blob();
+  const href = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = href;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(href);
+}
+
+export default function BackupRestorePanel() {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [config, setConfig] = useState<ScheduleConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [savingSchedule, setSavingSchedule] = useState(false);
+
+  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget>(null);
+  const [confirmText, setConfirmText] = useState('');
+  const [restoring, setRestoring] = useState(false);
+  const [restoreProgress, setRestoreProgress] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const loadSnapshots = useCallback(async () => {
+    const res = await fetch('/api/backup');
+    if (res.ok) {
+      const data = await res.json();
+      setSnapshots(data.data || []);
+    }
+  }, []);
+
+  const loadSchedule = useCallback(async () => {
+    const res = await fetch('/api/backup/schedule');
+    if (res.ok) {
+      const data = await res.json();
+      setConfig(data.data.config);
+    }
+  }, []);
+
+  useEffect(() => {
+    Promise.all([loadSnapshots(), loadSchedule()]).finally(() => setLoading(false));
+  }, [loadSnapshots, loadSchedule]);
+
+  const handleDownloadNew = async () => {
+    setDownloading(true);
+    try {
+      await downloadFromUrl('/api/backup/export', 'btc-tracker-backup.db');
+      toast({ title: 'Backup downloaded' });
+    } catch {
+      toast({ title: 'Failed to download backup', variant: 'destructive' });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleCreateServerSnapshot = async () => {
+    setCreating(true);
+    try {
+      const res = await fetch('/api/backup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
+      const data = await res.json();
+      if (data.success) {
+        toast({ title: 'Server snapshot created' });
+        await loadSnapshots();
+      } else {
+        toast({ title: 'Failed to create snapshot', description: data.error, variant: 'destructive' });
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (filename: string) => {
+    const res = await fetch(`/api/backup/${encodeURIComponent(filename)}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (data.success) {
+      toast({ title: 'Snapshot deleted' });
+      await loadSnapshots();
+    } else {
+      toast({ title: 'Failed to delete', description: data.error, variant: 'destructive' });
+    }
+  };
+
+  const handleFileSelected = (file: File | undefined) => {
+    if (!file) return;
+    setConfirmText('');
+    setRestoreTarget({ type: 'file', file });
+  };
+
+  const performRestore = async () => {
+    if (!restoreTarget) return;
+    setRestoring(true);
+    setRestoreProgress(0);
+    try {
+      let ok = false;
+      let errorMsg = 'Restore failed';
+
+      if (restoreTarget.type === 'file') {
+        const result = await uploadRestore(restoreTarget.file, setRestoreProgress);
+        ok = result.status === 200 && result.json?.success;
+        errorMsg = result.json?.error || errorMsg;
+      } else {
+        const res = await fetch('/api/backup/restore', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filename: restoreTarget.filename }),
+        });
+        const data = await res.json();
+        ok = res.status === 200 && data.success;
+        errorMsg = data.error || errorMsg;
+      }
+
+      if (ok) {
+        toast({ title: 'Restore complete', description: 'Reloading — you may need to sign in again.' });
+        setRestoreTarget(null);
+        setTimeout(() => { window.location.href = '/auth/signin'; }, 1800);
+      } else {
+        toast({ title: 'Restore failed', description: errorMsg, variant: 'destructive' });
+        setRestoring(false);
+      }
+    } catch {
+      toast({ title: 'Restore failed', variant: 'destructive' });
+      setRestoring(false);
+    }
+  };
+
+  const saveSchedule = async (updates: Partial<ScheduleConfig>) => {
+    setSavingSchedule(true);
+    try {
+      const res = await fetch('/api/backup/schedule', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setConfig(data.data.config);
+        toast({ title: 'Schedule updated' });
+      } else {
+        toast({ title: 'Failed to update schedule', description: data.error, variant: 'destructive' });
+      }
+    } finally {
+      setSavingSchedule(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-muted-foreground">Loading backups…</div>;
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <DatabaseIcon className="size-6" /> Backup &amp; Restore
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Full-database backups (all users&apos; data). Admin only.
+        </p>
+      </div>
+
+      {/* Create & download */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Create a backup</CardTitle>
+          <CardDescription>Download a snapshot to your computer, or keep one on the server.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Button onClick={handleDownloadNew} disabled={downloading}>
+            <DownloadIcon className="size-4 mr-2" />
+            {downloading ? 'Preparing…' : 'Download backup'}
+          </Button>
+          <Button variant="outline" onClick={handleCreateServerSnapshot} disabled={creating}>
+            <DatabaseIcon className="size-4 mr-2" />
+            {creating ? 'Creating…' : 'Create server snapshot'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Server snapshots */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Server snapshots</CardTitle>
+          <CardDescription>Snapshots stored on this server.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {snapshots.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No snapshots yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {snapshots.map((s) => (
+                <div key={s.filename} className="flex items-center justify-between gap-2 rounded-lg border p-3 text-sm">
+                  <div className="min-w-0">
+                    <div className="font-medium truncate">{s.filename}</div>
+                    <div className="text-muted-foreground text-xs">
+                      {new Date(s.createdAt).toLocaleString()} · {formatBytes(s.sizeBytes)} · {s.kind}
+                      {s.appVersion !== 'unknown' ? ` · v${s.appVersion}` : ''}
+                    </div>
+                  </div>
+                  <div className="flex gap-1 shrink-0">
+                    <Button variant="ghost" size="sm" title="Download"
+                      onClick={() => downloadFromUrl(`/api/backup/${encodeURIComponent(s.filename)}/download`, s.filename).catch(() => toast({ title: 'Download failed', variant: 'destructive' }))}>
+                      <DownloadIcon className="size-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" title="Restore"
+                      onClick={() => { setConfirmText(''); setRestoreTarget({ type: 'server', filename: s.filename }); }}>
+                      <RotateCcwIcon className="size-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" title="Delete" onClick={() => handleDelete(s.filename)}>
+                      <Trash2Icon className="size-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Restore from file */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Restore from a file</CardTitle>
+          <CardDescription className="text-destructive">
+            This replaces ALL current data for every user. Make a backup first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={(e) => { e.preventDefault(); setDragOver(false); handleFileSelected(e.dataTransfer.files?.[0]); }}
+            onClick={() => fileInputRef.current?.click()}
+            className={`cursor-pointer rounded-lg border-2 border-dashed p-6 text-center text-sm transition-colors ${dragOver ? 'border-primary bg-primary/5' : 'border-muted'}`}
+          >
+            <UploadIcon className="size-6 mx-auto mb-2 text-muted-foreground" />
+            Drop a <code>.db</code> or <code>.db.gz</code> backup here, or click to choose
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".db,.gz,application/octet-stream"
+              className="hidden"
+              onChange={(e) => handleFileSelected(e.target.files?.[0] || undefined)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Schedule */}
+      {config && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><ClockIcon className="size-5" /> Automatic backups</CardTitle>
+            <CardDescription>Periodic server snapshots with retention.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="bk-enabled">Enabled</Label>
+              <Switch id="bk-enabled" checked={config.enabled}
+                onCheckedChange={(v) => saveSchedule({ enabled: v })} disabled={savingSchedule} />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div>
+                <Label htmlFor="bk-interval">Every (hours)</Label>
+                <Input id="bk-interval" type="number" min={1} defaultValue={config.intervalHours}
+                  onBlur={(e) => { const v = Number(e.target.value); if (v >= 1 && v !== config.intervalHours) saveSchedule({ intervalHours: v }); }} />
+              </div>
+              <div>
+                <Label htmlFor="bk-keeplast">Keep last (count)</Label>
+                <Input id="bk-keeplast" type="number" min={0} defaultValue={config.retention.keepLast ?? 0}
+                  onBlur={(e) => saveSchedule({ retention: { ...config.retention, keepLast: Number(e.target.value) } })} />
+              </div>
+              <div>
+                <Label htmlFor="bk-keepdays">Keep days</Label>
+                <Input id="bk-keepdays" type="number" min={0} defaultValue={config.retention.keepDays ?? 0}
+                  onBlur={(e) => saveSchedule({ retention: { ...config.retention, keepDays: Number(e.target.value) } })} />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="bk-gzip">Compress (gzip)</Label>
+              <Switch id="bk-gzip" checked={config.gzip} onCheckedChange={(v) => saveSchedule({ gzip: v })} disabled={savingSchedule} />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {config.lastRunAt ? `Last run: ${new Date(config.lastRunAt).toLocaleString()}` : 'Never run yet'}
+              {config.lastError ? ` · last error: ${config.lastError}` : ''}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Destructive restore confirmation */}
+      <Dialog open={restoreTarget !== null} onOpenChange={(open) => { if (!open && !restoring) setRestoreTarget(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-destructive">
+              <AlertTriangleIcon className="size-5" /> Confirm restore
+            </DialogTitle>
+            <DialogDescription asChild>
+              <div className="space-y-2 text-sm">
+                <p>
+                  This will <strong>permanently replace the entire database</strong> — every user&apos;s
+                  transactions, wallets, settings and accounts — with the contents of{' '}
+                  <code>{restoreTarget?.type === 'file' ? restoreTarget.file.name : restoreTarget?.type === 'server' ? restoreTarget.filename : ''}</code>.
+                </p>
+                <p>A safety backup of the current database is taken automatically first.</p>
+                <p className="text-muted-foreground">
+                  Note: exchange API credentials only decrypt if this backup came from an install with the
+                  same <code>NEXTAUTH_SECRET</code>. You will likely need to sign in again afterwards.
+                </p>
+                <p>Type <strong>RESTORE</strong> to confirm:</p>
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+
+          <Input value={confirmText} onChange={(e) => setConfirmText(e.target.value)} placeholder="RESTORE" disabled={restoring} />
+          {restoring && restoreTarget?.type === 'file' && <Progress value={restoreProgress} className="mt-2" />}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRestoreTarget(null)} disabled={restoring}>Cancel</Button>
+            <Button variant="destructive" onClick={performRestore} disabled={restoring || confirmText !== 'RESTORE'}>
+              {restoring ? 'Restoring…' : 'Restore'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function uploadRestore(file: File, onProgress: (pct: number) => void): Promise<{ status: number; json: { success?: boolean; error?: string } | null }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/backup/restore');
+    xhr.upload.onprogress = (e) => { if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100)); };
+    xhr.onload = () => {
+      let json: { success?: boolean; error?: string } | null = null;
+      try { json = JSON.parse(xhr.responseText); } catch { json = null; }
+      resolve({ status: xhr.status, json });
+    };
+    xhr.onerror = () => reject(new Error('Network error'));
+    const fd = new FormData();
+    fd.append('file', file);
+    xhr.send(fd);
+  });
+}

--- a/src/lib/app-initialization.ts
+++ b/src/lib/app-initialization.ts
@@ -1,5 +1,6 @@
 import { PriceScheduler } from './price-scheduler';
 import { DCAScheduler } from './dca-scheduler';
+import { BackupScheduler } from './backup-scheduler';
 import { ExchangeRateService } from './exchange-rate-service';
 import { HistoricalDataService } from './historical-data-service';
 import { SettingsService } from './settings-service';
@@ -84,6 +85,14 @@ export class AppInitializationService {
       const dcaStats = await DCAScheduler.getStatistics();
       console.log(`[DCA] Scheduler started (${dcaStats.active} active)`);
 
+      console.log('[BACKUP] Starting backup scheduler...');
+      try {
+        await BackupScheduler.start();
+        console.log('[OK] Backup scheduler ready');
+      } catch (error) {
+        console.error('[WARN] Backup scheduler failed:', error);
+      }
+
       this.setupShutdownHandlers();
 
     } catch (error) {
@@ -100,6 +109,7 @@ export class AppInitializationService {
       console.log('[STOP] Shutting down...');
       PriceScheduler.stop();
       DCAScheduler.stop();
+      BackupScheduler.stop();
       console.log('[OK] Stopped');
     };
 
@@ -127,6 +137,7 @@ export class AppInitializationService {
   static async restart(): Promise<void> {
     console.log('[SYNC] Restarting services...');
     PriceScheduler.stop();
+    BackupScheduler.stop();
     this.isInitialized = false;
     this.initPromise = null;
     await this.initialize();

--- a/src/lib/backup-scheduler.ts
+++ b/src/lib/backup-scheduler.ts
@@ -1,0 +1,71 @@
+import { BackupService, SnapshotMetadata } from './backup-service';
+
+/**
+ * BackupScheduler
+ *
+ * Periodically creates automatic ("scheduled") snapshots and applies the
+ * retention policy. Follows the same static-class pattern as PriceScheduler.
+ * Configuration lives in BackupService's on-disk config (see getConfig).
+ */
+export class BackupScheduler {
+  private static interval: NodeJS.Timeout | null = null;
+  private static isRunning = false;
+
+  static async start(): Promise<void> {
+    if (this.interval) return; // already scheduled
+
+    const config = await BackupService.getConfig();
+    if (!config.enabled) {
+      this.isRunning = false;
+      console.log('[BACKUP] Scheduler disabled');
+      return;
+    }
+
+    const intervalMs = Math.max(1, config.intervalHours) * 60 * 60 * 1000;
+    console.log(`[BACKUP] Scheduling automatic backups every ${config.intervalHours}h`);
+
+    this.interval = setInterval(() => {
+      this.runNow().catch((error) => console.error('[BACKUP] Scheduled backup failed:', error));
+    }, intervalMs);
+    this.isRunning = true;
+  }
+
+  static stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.isRunning = false;
+  }
+
+  static async restart(): Promise<void> {
+    this.stop();
+    await this.start();
+  }
+
+  /**
+   * Create one scheduled snapshot now and apply retention. Records lastRunAt /
+   * lastError in the config. Used by the interval and the manual "run now" action.
+   */
+  static async runNow(): Promise<SnapshotMetadata> {
+    const config = await BackupService.getConfig();
+    try {
+      const meta = await BackupService.createSnapshot({ kind: 'scheduled', gzip: config.gzip });
+      await BackupService.applyRetention(config.retention);
+      await BackupService.saveConfig({ lastRunAt: new Date().toISOString(), lastError: null });
+      console.log(`[BACKUP] Scheduled backup created: ${meta.filename}`);
+      return meta;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      await BackupService.saveConfig({ lastError: message }).catch(() => {});
+      throw error;
+    }
+  }
+
+  static getStatus() {
+    return {
+      isRunning: this.isRunning,
+      scheduled: this.interval !== null,
+    };
+  }
+}

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -1,0 +1,603 @@
+import { prisma } from './prisma';
+import { PrismaClient } from '@prisma/client';
+import path from 'path';
+import crypto from 'crypto';
+import { spawn } from 'child_process';
+import { promises as fsp } from 'fs';
+import { createReadStream, createWriteStream, existsSync } from 'fs';
+import { createGzip, gunzipSync } from 'zlib';
+import { pipeline } from 'stream/promises';
+
+/**
+ * BackupService
+ *
+ * Full-database (file-level) snapshot management for the single SQLite database.
+ * Snapshots are produced with SQLite `VACUUM INTO`, which checkpoints WAL into a
+ * clean, consistent single file (a naive copy could be torn while WAL is active).
+ *
+ * Restore mechanics live in the same class (see restore-* methods) but are kept
+ * separate from the read-only snapshot surface for clarity.
+ */
+
+export type BackupKind = 'manual' | 'scheduled' | 'safety';
+
+export interface SnapshotMetadata {
+  filename: string;
+  sizeBytes: number;
+  createdAt: string;       // ISO
+  appVersion: string;
+  schemaVersion: string;   // latest applied prisma migration name
+  gzip: boolean;
+  kind: BackupKind;
+  sha256?: string;
+  label?: string;
+}
+
+export interface RetentionPolicy {
+  keepLast?: number | null;
+  keepDays?: number | null;
+}
+
+export interface BackupConfig {
+  enabled: boolean;
+  intervalHours: number;
+  gzip: boolean;
+  retention: RetentionPolicy;
+  lastRunAt: string | null;
+  lastError: string | null;
+}
+
+export const DEFAULT_BACKUP_CONFIG: BackupConfig = {
+  enabled: false,
+  intervalHours: 24,
+  gzip: true,
+  retention: { keepLast: 7, keepDays: 30 },
+  lastRunAt: null,
+  lastError: null,
+};
+
+export interface RestoreResult {
+  success: boolean;
+  restoredFrom: string;
+  safetyBackup: string;
+  upgraded: boolean;
+}
+
+// Process-global restore guard. All deploy targets are single-process
+// (Docker standalone / Electron-spawned server / `next start`), so an in-memory
+// flag is authoritative. (A clustered multi-worker deployment would defeat this.)
+let RESTORE_LOCK = false;
+
+export class BackupService {
+  private static readonly CONFIG_FILENAME = 'backup-config.json';
+
+  // ---------------------------------------------------------------------------
+  // Paths
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve the absolute filesystem path of the live SQLite database from
+   * DATABASE_URL (format `file:<path>`). Relative paths are resolved against the
+   * process working directory, matching how Prisma/`scripts/migrate.js` treat them.
+   */
+  static resolveDbPath(): string {
+    const url = process.env.DATABASE_URL || '';
+    if (!url.startsWith('file:')) {
+      throw new Error(`Unsupported DATABASE_URL for backups (expected file: URL): "${url}"`);
+    }
+    const raw = url.replace('file:', '').trim();
+    if (path.isAbsolute(raw)) return raw;
+
+    // Prisma resolves relative SQLite paths relative to the schema directory
+    // (`prisma/`), not the cwd — e.g. `file:./test.db` lives at `prisma/test.db`
+    // and `file:./prisma/dev.db` at `prisma/prisma/dev.db`. Prefer the schema-dir
+    // location, falling back to cwd-relative if that's where the file actually is.
+    const candidates = [
+      path.resolve(process.cwd(), 'prisma', raw),
+      path.resolve(process.cwd(), raw),
+    ];
+    return candidates.find((c) => existsSync(c)) ?? candidates[0];
+  }
+
+  /**
+   * Backups live next to the database file (`<dbDir>/backups`) so they land on the
+   * same volume/filesystem as the DB — important for atomic renames during restore
+   * and for the Docker volume / Electron userData dir.
+   */
+  static getBackupDir(): string {
+    return path.join(path.dirname(this.resolveDbPath()), 'backups');
+  }
+
+  static getStagingDir(): string {
+    return path.join(this.getBackupDir(), '.staging');
+  }
+
+  static async ensureBackupDir(): Promise<void> {
+    await fsp.mkdir(this.getBackupDir(), { recursive: true });
+  }
+
+  /**
+   * Resolve a snapshot filename to an absolute path, guarding against path
+   * traversal (only basenames inside the backup dir are ever accessed).
+   */
+  static getSnapshotPath(filename: string): string {
+    const base = path.basename(filename);
+    // Reject anything that isn't a bare filename (no separators, no traversal).
+    if (!base || base !== filename || base === '.' || base === '..') {
+      throw new Error(`Invalid backup filename: ${filename}`);
+    }
+    return path.join(this.getBackupDir(), base);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshot creation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Copy the live DB into `targetPath` as a consistent single file.
+   * Prefers `VACUUM INTO`; falls back to a WAL checkpoint + file copy if the
+   * driver refuses VACUUM inside an implicit transaction.
+   */
+  static async vacuumInto(targetPath: string): Promise<void> {
+    const escaped = targetPath.replace(/'/g, "''");
+    try {
+      await prisma.$executeRawUnsafe(`VACUUM INTO '${escaped}'`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (/transaction/i.test(msg)) {
+        // Fallback: force a full checkpoint then copy the (now consistent) file.
+        await prisma.$executeRawUnsafe('PRAGMA wal_checkpoint(TRUNCATE)');
+        await fsp.copyFile(this.resolveDbPath(), targetPath);
+        return;
+      }
+      throw error;
+    }
+  }
+
+  static async createSnapshot(opts: { kind?: BackupKind; gzip?: boolean; label?: string } = {}): Promise<SnapshotMetadata> {
+    const kind: BackupKind = opts.kind ?? 'manual';
+    const gzip = opts.gzip ?? false;
+
+    await this.ensureBackupDir();
+    const backupDir = this.getBackupDir();
+    const dbPath = this.resolveDbPath();
+
+    // Disk-space guard: the VACUUM/copy step writes a full-size file first
+    // (gzip only shrinks it afterwards), so require ~1.2x the DB size either way.
+    const dbSize = (await fsp.stat(dbPath)).size;
+    const needed = Math.ceil(dbSize * 1.2);
+    const free = await this.freeDiskBytes(backupDir);
+    if (free < needed) {
+      throw new Error(`Not enough disk space for backup: need ~${needed} bytes, have ${free} bytes free`);
+    }
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const prefix = kind === 'safety' ? 'pre-restore' : kind === 'scheduled' ? 'btc-backup-auto' : 'btc-backup';
+    const filename = `${prefix}-${stamp}.db${gzip ? '.gz' : ''}`;
+    const finalPath = path.join(backupDir, filename);
+    const tmpPath = path.join(backupDir, `.tmp-${stamp}.db`);
+
+    try {
+      await this.vacuumInto(tmpPath);
+
+      if (gzip) {
+        await pipeline(createReadStream(tmpPath), createGzip(), createWriteStream(finalPath));
+        await fsp.unlink(tmpPath);
+      } else {
+        await fsp.rename(tmpPath, finalPath);
+      }
+
+      const sha256 = await this.sha256File(finalPath);
+      const sizeBytes = (await fsp.stat(finalPath)).size;
+
+      const metadata: SnapshotMetadata = {
+        filename,
+        sizeBytes,
+        createdAt: new Date().toISOString(),
+        appVersion: await this.getAppVersion(),
+        schemaVersion: await this.getSchemaVersion(),
+        gzip,
+        kind,
+        sha256,
+        ...(opts.label ? { label: opts.label } : {}),
+      };
+
+      await fsp.writeFile(`${finalPath}.json`, JSON.stringify(metadata, null, 2), 'utf-8');
+      return metadata;
+    } catch (error) {
+      // Best-effort cleanup of partial artifacts.
+      await fsp.unlink(tmpPath).catch(() => {});
+      await fsp.unlink(finalPath).catch(() => {});
+      throw error;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Listing / reading / deleting
+  // ---------------------------------------------------------------------------
+
+  static async listSnapshots(): Promise<SnapshotMetadata[]> {
+    await this.ensureBackupDir();
+    const backupDir = this.getBackupDir();
+    const entries = await fsp.readdir(backupDir);
+
+    const snapshots: SnapshotMetadata[] = [];
+    for (const name of entries) {
+      if (!this.isSnapshotFile(name)) continue;
+      const full = path.join(backupDir, name);
+
+      let meta: SnapshotMetadata | null = null;
+      try {
+        const sidecar = await fsp.readFile(`${full}.json`, 'utf-8');
+        meta = JSON.parse(sidecar) as SnapshotMetadata;
+      } catch {
+        meta = null;
+      }
+
+      if (!meta) {
+        // Synthesize metadata for orphaned/manually-added snapshot files.
+        const stat = await fsp.stat(full);
+        meta = {
+          filename: name,
+          sizeBytes: stat.size,
+          createdAt: stat.mtime.toISOString(),
+          appVersion: 'unknown',
+          schemaVersion: 'unknown',
+          gzip: name.endsWith('.gz'),
+          kind: this.inferKind(name),
+        };
+      }
+      snapshots.push(meta);
+    }
+
+    return snapshots.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  static async readSnapshot(filename: string): Promise<Buffer> {
+    return fsp.readFile(this.getSnapshotPath(filename));
+  }
+
+  static async deleteSnapshot(filename: string): Promise<void> {
+    const p = this.getSnapshotPath(filename);
+    await fsp.unlink(p);
+    await fsp.unlink(`${p}.json`).catch(() => {});
+  }
+
+  /**
+   * Apply a retention policy to AUTOMATIC (scheduled) snapshots only.
+   * Manual and safety backups are never removed by retention.
+   */
+  static async applyRetention(policy: RetentionPolicy): Promise<string[]> {
+    const scheduled = (await this.listSnapshots())
+      .filter((s) => s.kind === 'scheduled')
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+    // NOTE: avoid Set iteration/spread here — the project's tsconfig targets ES5
+    // without downlevelIteration, under which ts-jest mis-compiles `[...set]`/
+    // `for..of set`. Use a plain array with manual dedup instead.
+    const toDelete: string[] = [];
+    const mark = (filename: string) => {
+      if (toDelete.indexOf(filename) === -1) toDelete.push(filename);
+    };
+
+    if (policy.keepLast != null && policy.keepLast >= 0) {
+      scheduled.slice(policy.keepLast).forEach((s) => mark(s.filename));
+    }
+    if (policy.keepDays != null && policy.keepDays >= 0) {
+      const cutoff = Date.now() - policy.keepDays * 24 * 60 * 60 * 1000;
+      scheduled
+        .filter((s) => new Date(s.createdAt).getTime() < cutoff)
+        .forEach((s) => mark(s.filename));
+    }
+
+    const deleted: string[] = [];
+    for (let i = 0; i < toDelete.length; i++) {
+      try {
+        await this.deleteSnapshot(toDelete[i]);
+        deleted.push(toDelete[i]);
+      } catch {
+        // ignore individual deletion errors during the retention sweep
+      }
+    }
+    return deleted;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Restore (destructive — replaces the live database)
+  // ---------------------------------------------------------------------------
+
+  static isRestoreInProgress(): boolean {
+    return RESTORE_LOCK;
+  }
+
+  /** Restore from an uploaded backup buffer (gzip auto-detected). */
+  static async restoreFromBuffer(buffer: Buffer, opts: { sourceName?: string } = {}): Promise<RestoreResult> {
+    await fsp.mkdir(this.getStagingDir(), { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const staged = path.join(this.getStagingDir(), `upload-${stamp}.db`);
+
+    const isGzip = buffer.length > 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
+    if (isGzip) {
+      await fsp.writeFile(staged, gunzipSync(buffer));
+    } else {
+      await fsp.writeFile(staged, buffer);
+    }
+
+    return this.performRestore(staged, opts.sourceName || 'upload');
+  }
+
+  /** Restore from a snapshot already stored on the server. */
+  static async restoreFromServerSnapshot(filename: string): Promise<RestoreResult> {
+    const buffer = await this.readSnapshot(filename); // also runs the traversal guard
+    return this.restoreFromBuffer(buffer, { sourceName: filename });
+  }
+
+  /**
+   * The destructive core. Sequence: validate (out-of-band) → safety backup →
+   * stop schedulers → disconnect → swap file (+ clear WAL sidecars) → reconnect
+   * → migrate up if older → restart services. Rolls back to the safety backup on
+   * any post-swap failure.
+   */
+  private static async performRestore(stagedPath: string, sourceName: string): Promise<RestoreResult> {
+    if (RESTORE_LOCK) {
+      await fsp.unlink(stagedPath).catch(() => {});
+      throw new Error('RESTORE_IN_PROGRESS');
+    }
+    RESTORE_LOCK = true;
+
+    const dbPath = this.resolveDbPath();
+    const { prisma } = await import('./prisma');
+
+    try {
+      // 1. Validate the staged file without touching the live connection.
+      const { stagedLatest } = await this.validateStagedDb(stagedPath);
+      const currentLatest = await this.getSchemaVersion();
+      const needsUpgrade = stagedLatest !== 'unknown' && stagedLatest !== currentLatest;
+
+      // 2. Safety backup of the CURRENT database. Abort if it can't be made.
+      let safety: SnapshotMetadata;
+      try {
+        safety = await this.createSnapshot({ kind: 'safety', gzip: false });
+      } catch (e) {
+        throw new Error(`Aborting restore: failed to create safety backup: ${e instanceof Error ? e.message : 'unknown'}`);
+      }
+
+      // 3. Stop background work that touches the DB.
+      await this.stopSchedulers();
+
+      // 4. Swap the file in, then bring the schema up to date if the backup is older.
+      try {
+        await prisma.$disconnect();
+        await this.swapInFile(stagedPath, dbPath);
+        await prisma.$connect();
+        await prisma.$queryRawUnsafe('SELECT 1');
+        if (needsUpgrade) await this.runMigrations();
+        await this.restartServices();
+        return { success: true, restoredFrom: sourceName, safetyBackup: safety.filename, upgraded: needsUpgrade };
+      } catch (err) {
+        // 5. Roll back to the safety backup.
+        try {
+          await prisma.$disconnect().catch(() => {});
+          await this.swapInFile(this.getSnapshotPath(safety.filename), dbPath);
+          await prisma.$connect();
+          await this.restartServices();
+        } catch (rollbackErr) {
+          throw new Error(
+            `Restore FAILED and automatic rollback also FAILED. Your data may be inconsistent. ` +
+            `Restore the safety backup "${safety.filename}" manually. Original error: ${err instanceof Error ? err.message : 'unknown'}; ` +
+            `rollback error: ${rollbackErr instanceof Error ? rollbackErr.message : 'unknown'}`
+          );
+        }
+        throw new Error(`Restore failed (rolled back to safety backup "${safety.filename}"): ${err instanceof Error ? err.message : 'unknown'}`);
+      }
+    } finally {
+      RESTORE_LOCK = false;
+      await fsp.unlink(stagedPath).catch(() => {});
+    }
+  }
+
+  /** Validate an uploaded/staged SQLite file out-of-band (never via the live client). */
+  private static async validateStagedDb(stagedPath: string): Promise<{ stagedLatest: string }> {
+    // Cheap magic-header check first.
+    const fd = await fsp.open(stagedPath, 'r');
+    try {
+      const head = Buffer.alloc(16);
+      await fd.read(head, 0, 16, 0);
+      if (head.toString('binary', 0, 15) !== 'SQLite format 3') {
+        throw new Error('Uploaded file is not a SQLite database');
+      }
+    } finally {
+      await fd.close();
+    }
+
+    const probe = new PrismaClient({ datasources: { db: { url: `file:${stagedPath}` } } });
+    try {
+      await probe.$connect();
+
+      const required = ['users', 'bitcoin_transactions', 'app_settings', '_prisma_migrations'];
+      for (let i = 0; i < required.length; i++) {
+        const rows = await probe.$queryRawUnsafe(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='${required[i]}'`
+        );
+        if (!Array.isArray(rows) || rows.length === 0) {
+          throw new Error(`Backup is missing required table: ${required[i]}`);
+        }
+      }
+
+      const appliedRows = await probe.$queryRawUnsafe(
+        'SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL ORDER BY finished_at DESC'
+      );
+      const applied: string[] = Array.isArray(appliedRows)
+        ? appliedRows.map((r: { migration_name: string }) => r.migration_name)
+        : [];
+
+      const known = await this.knownMigrations();
+      if (known.length) {
+        for (let i = 0; i < applied.length; i++) {
+          if (known.indexOf(applied[i]) === -1) {
+            throw new Error(`Backup was created by a newer app version (unknown migration "${applied[i]}"). Refusing to restore.`);
+          }
+        }
+      }
+
+      return { stagedLatest: applied[0] || 'unknown' };
+    } finally {
+      await probe.$disconnect().catch(() => {});
+    }
+  }
+
+  private static async knownMigrations(): Promise<string[]> {
+    try {
+      const dir = path.join(process.cwd(), 'prisma', 'migrations');
+      const entries = await fsp.readdir(dir, { withFileTypes: true });
+      return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+      return [];
+    }
+  }
+
+  /** Atomically replace the DB file with `source`, clearing WAL sidecars first. */
+  private static async swapInFile(source: string, dbPath: string): Promise<void> {
+    await fsp.rm(`${dbPath}-wal`, { force: true });
+    await fsp.rm(`${dbPath}-shm`, { force: true });
+    await fsp.rm(`${dbPath}-journal`, { force: true });
+    const tmp = `${dbPath}.restore-tmp`;
+    await fsp.copyFile(source, tmp);
+    await fsp.rename(tmp, dbPath);
+  }
+
+  private static async stopSchedulers(): Promise<void> {
+    // Literal import paths (not a variable) so the bundler can resolve them and
+    // doesn't emit a "request of a dependency is an expression" warning.
+    try { (await import('./price-scheduler')).PriceScheduler?.stop?.(); } catch { /* noop */ }
+    try { (await import('./dca-scheduler')).DCAScheduler?.stop?.(); } catch { /* noop */ }
+    try { (await import('./backup-scheduler')).BackupScheduler?.stop?.(); } catch { /* noop */ }
+  }
+
+  private static async restartServices(): Promise<void> {
+    try {
+      const { AppInitializationService } = await import('./app-initialization');
+      await AppInitializationService.restart();
+    } catch (e) {
+      console.error('Failed to restart services after restore:', e);
+    }
+  }
+
+  private static runMigrations(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [path.join(process.cwd(), 'scripts', 'migrate.js')], {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: 'inherit',
+      });
+      child.on('error', reject);
+      child.on('exit', (code: number) => (code === 0 ? resolve() : reject(new Error(`migrate.js exited with code ${code}`))));
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Schedule / retention config (stored on disk, not in the DB, so a restore
+  // can't silently overwrite the backup schedule).
+  // ---------------------------------------------------------------------------
+
+  static getConfigPath(): string {
+    return path.join(this.getBackupDir(), this.CONFIG_FILENAME);
+  }
+
+  static async getConfig(): Promise<BackupConfig> {
+    try {
+      const raw = await fsp.readFile(this.getConfigPath(), 'utf-8');
+      const parsed = JSON.parse(raw);
+      return {
+        ...DEFAULT_BACKUP_CONFIG,
+        ...parsed,
+        retention: { ...DEFAULT_BACKUP_CONFIG.retention, ...(parsed.retention || {}) },
+      };
+    } catch {
+      return { ...DEFAULT_BACKUP_CONFIG, retention: { ...DEFAULT_BACKUP_CONFIG.retention } };
+    }
+  }
+
+  static async saveConfig(updates: Partial<BackupConfig>): Promise<BackupConfig> {
+    const current = await this.getConfig();
+    const merged: BackupConfig = {
+      ...current,
+      ...updates,
+      retention: { ...current.retention, ...(updates.retention || {}) },
+    };
+    await this.ensureBackupDir();
+    await fsp.writeFile(this.getConfigPath(), JSON.stringify(merged, null, 2), 'utf-8');
+    return merged;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata helpers
+  // ---------------------------------------------------------------------------
+
+  static async getAppVersion(): Promise<string> {
+    try {
+      const v = await fsp.readFile(path.join(process.cwd(), 'VERSION'), 'utf-8');
+      const trimmed = v.trim();
+      if (trimmed) return trimmed;
+    } catch {
+      /* fall through */
+    }
+    try {
+      const pkg = await fsp.readFile(path.join(process.cwd(), 'package.json'), 'utf-8');
+      return JSON.parse(pkg).version || 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  static async getSchemaVersion(): Promise<string> {
+    try {
+      const rows = await prisma.$queryRawUnsafe<Array<{ migration_name: string }>>(
+        'SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL ORDER BY finished_at DESC LIMIT 1'
+      );
+      return rows[0]?.migration_name ?? 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  /**
+   * Free bytes available on the filesystem holding `dir`. Returns Infinity if the
+   * platform/runtime doesn't support statfs, so the disk-space guard never blocks
+   * a backup just because it can't measure.
+   */
+  static async freeDiskBytes(dir: string): Promise<number> {
+    try {
+      const stats = await (fsp as unknown as { statfs: (p: string) => Promise<{ bavail: number; bsize: number }> }).statfs(dir);
+      return stats.bavail * stats.bsize;
+    } catch {
+      return Number.POSITIVE_INFINITY;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private static isSnapshotFile(name: string): boolean {
+    if (name.startsWith('.tmp-')) return false;
+    if (name.endsWith('.json')) return false;
+    return name.endsWith('.db') || name.endsWith('.db.gz');
+  }
+
+  private static inferKind(name: string): BackupKind {
+    if (name.startsWith('pre-restore')) return 'safety';
+    if (name.startsWith('btc-backup-auto')) return 'scheduled';
+    return 'manual';
+  }
+
+  private static sha256File(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const hash = crypto.createHash('sha256');
+      const stream = createReadStream(filePath);
+      stream.on('error', reject);
+      stream.on('data', (chunk) => hash.update(chunk));
+      stream.on('end', () => resolve(hash.digest('hex')));
+    });
+  }
+}

--- a/src/lib/backup-service.ts
+++ b/src/lib/backup-service.ts
@@ -134,33 +134,58 @@ export class BackupService {
   // ---------------------------------------------------------------------------
 
   /**
-   * Copy the live DB into `targetPath` as a consistent single file.
-   * Prefers `VACUUM INTO`; falls back to a WAL checkpoint + file copy if the
-   * driver refuses VACUUM inside an implicit transaction.
+   * Copy `dbPath` (open on `client`) into `targetPath` as a consistent single
+   * file. Prefers `VACUUM INTO`; falls back to a WAL checkpoint + file copy if
+   * the driver refuses VACUUM inside an implicit transaction.
    */
-  static async vacuumInto(targetPath: string): Promise<void> {
+  static async vacuumIntoWith(client: PrismaClient, dbPath: string, targetPath: string): Promise<void> {
     const escaped = targetPath.replace(/'/g, "''");
     try {
-      await prisma.$executeRawUnsafe(`VACUUM INTO '${escaped}'`);
+      await client.$executeRawUnsafe(`VACUUM INTO '${escaped}'`);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (/transaction/i.test(msg)) {
         // Fallback: force a full checkpoint then copy the (now consistent) file.
-        await prisma.$executeRawUnsafe('PRAGMA wal_checkpoint(TRUNCATE)');
-        await fsp.copyFile(this.resolveDbPath(), targetPath);
+        await client.$executeRawUnsafe('PRAGMA wal_checkpoint(TRUNCATE)');
+        await fsp.copyFile(dbPath, targetPath);
         return;
       }
       throw error;
     }
   }
 
-  static async createSnapshot(opts: { kind?: BackupKind; gzip?: boolean; label?: string } = {}): Promise<SnapshotMetadata> {
-    const kind: BackupKind = opts.kind ?? 'manual';
-    const gzip = opts.gzip ?? false;
+  /** Convenience wrapper that snapshots the live database. */
+  static vacuumInto(targetPath: string): Promise<void> {
+    return this.vacuumIntoWith(prisma, this.resolveDbPath(), targetPath);
+  }
 
-    await this.ensureBackupDir();
-    const backupDir = this.getBackupDir();
-    const dbPath = this.resolveDbPath();
+  /** Snapshot the live database (default client/paths). */
+  static createSnapshot(opts: { kind?: BackupKind; gzip?: boolean; label?: string } = {}): Promise<SnapshotMetadata> {
+    return this.createSnapshotFrom({
+      client: prisma,
+      dbPath: this.resolveDbPath(),
+      backupDir: this.getBackupDir(),
+      ...opts,
+    });
+  }
+
+  /**
+   * Snapshot an arbitrary database (explicit client + paths). Used by
+   * createSnapshot for the live DB, and by tests/restore against isolated DBs.
+   */
+  static async createSnapshotFrom(params: {
+    client: PrismaClient;
+    dbPath: string;
+    backupDir: string;
+    kind?: BackupKind;
+    gzip?: boolean;
+    label?: string;
+  }): Promise<SnapshotMetadata> {
+    const { client, dbPath, backupDir } = params;
+    const kind: BackupKind = params.kind ?? 'manual';
+    const gzip = params.gzip ?? false;
+
+    await fsp.mkdir(backupDir, { recursive: true });
 
     // Disk-space guard: the VACUUM/copy step writes a full-size file first
     // (gzip only shrinks it afterwards), so require ~1.2x the DB size either way.
@@ -178,7 +203,7 @@ export class BackupService {
     const tmpPath = path.join(backupDir, `.tmp-${stamp}.db`);
 
     try {
-      await this.vacuumInto(tmpPath);
+      await this.vacuumIntoWith(client, dbPath, tmpPath);
 
       if (gzip) {
         await pipeline(createReadStream(tmpPath), createGzip(), createWriteStream(finalPath));
@@ -195,11 +220,11 @@ export class BackupService {
         sizeBytes,
         createdAt: new Date().toISOString(),
         appVersion: await this.getAppVersion(),
-        schemaVersion: await this.getSchemaVersion(),
+        schemaVersion: await this.schemaVersionOf(client),
         gzip,
         kind,
         sha256,
-        ...(opts.label ? { label: opts.label } : {}),
+        ...(params.label ? { label: params.label } : {}),
       };
 
       await fsp.writeFile(`${finalPath}.json`, JSON.stringify(metadata, null, 2), 'utf-8');
@@ -333,10 +358,9 @@ export class BackupService {
   }
 
   /**
-   * The destructive core. Sequence: validate (out-of-band) → safety backup →
-   * stop schedulers → disconnect → swap file (+ clear WAL sidecars) → reconnect
-   * → migrate up if older → restart services. Rolls back to the safety backup on
-   * any post-swap failure.
+   * Production restore wrapper: holds the single-flight lock, stops/restarts
+   * background schedulers around the swap, and delegates the destructive work to
+   * restoreCore against the live database.
    */
   private static async performRestore(stagedPath: string, sourceName: string): Promise<RestoreResult> {
     if (RESTORE_LOCK) {
@@ -345,54 +369,83 @@ export class BackupService {
     }
     RESTORE_LOCK = true;
 
-    const dbPath = this.resolveDbPath();
     const { prisma } = await import('./prisma');
+    let stopped = false;
 
     try {
-      // 1. Validate the staged file without touching the live connection.
-      const { stagedLatest } = await this.validateStagedDb(stagedPath);
-      const currentLatest = await this.getSchemaVersion();
-      const needsUpgrade = stagedLatest !== 'unknown' && stagedLatest !== currentLatest;
-
-      // 2. Safety backup of the CURRENT database. Abort if it can't be made.
-      let safety: SnapshotMetadata;
-      try {
-        safety = await this.createSnapshot({ kind: 'safety', gzip: false });
-      } catch (e) {
-        throw new Error(`Aborting restore: failed to create safety backup: ${e instanceof Error ? e.message : 'unknown'}`);
-      }
-
-      // 3. Stop background work that touches the DB.
-      await this.stopSchedulers();
-
-      // 4. Swap the file in, then bring the schema up to date if the backup is older.
-      try {
-        await prisma.$disconnect();
-        await this.swapInFile(stagedPath, dbPath);
-        await prisma.$connect();
-        await prisma.$queryRawUnsafe('SELECT 1');
-        if (needsUpgrade) await this.runMigrations();
-        await this.restartServices();
-        return { success: true, restoredFrom: sourceName, safetyBackup: safety.filename, upgraded: needsUpgrade };
-      } catch (err) {
-        // 5. Roll back to the safety backup.
-        try {
-          await prisma.$disconnect().catch(() => {});
-          await this.swapInFile(this.getSnapshotPath(safety.filename), dbPath);
-          await prisma.$connect();
-          await this.restartServices();
-        } catch (rollbackErr) {
-          throw new Error(
-            `Restore FAILED and automatic rollback also FAILED. Your data may be inconsistent. ` +
-            `Restore the safety backup "${safety.filename}" manually. Original error: ${err instanceof Error ? err.message : 'unknown'}; ` +
-            `rollback error: ${rollbackErr instanceof Error ? rollbackErr.message : 'unknown'}`
-          );
-        }
-        throw new Error(`Restore failed (rolled back to safety backup "${safety.filename}"): ${err instanceof Error ? err.message : 'unknown'}`);
-      }
+      const result = await this.restoreCore({
+        stagedPath,
+        client: prisma,
+        dbPath: this.resolveDbPath(),
+        backupDir: this.getBackupDir(),
+        // Stop schedulers only AFTER validation passes (so a bad upload doesn't
+        // needlessly bounce the app's background work).
+        onBeforeSwap: async () => { stopped = true; await this.stopSchedulers(); },
+        runMigrations: () => this.runMigrations(),
+      });
+      return { success: true, restoredFrom: sourceName, safetyBackup: result.safetyBackup, upgraded: result.upgraded };
     } finally {
+      if (stopped) await this.restartServices();
       RESTORE_LOCK = false;
       await fsp.unlink(stagedPath).catch(() => {});
+    }
+  }
+
+  /**
+   * The DB-agnostic destructive core (no scheduler/service concerns, no global
+   * singletons) so it can be exercised in isolation against a throwaway DB.
+   * Sequence: validate (out-of-band) → [onBeforeSwap] → safety backup →
+   * disconnect → swap file (+ clear WAL sidecars) → reconnect → migrate up if
+   * older. Rolls back to the safety backup on any post-swap failure.
+   */
+  static async restoreCore(params: {
+    stagedPath: string;
+    client: PrismaClient;
+    dbPath: string;
+    backupDir: string;
+    onBeforeSwap?: () => Promise<void>;
+    runMigrations?: () => Promise<void>;
+  }): Promise<{ safetyBackup: string; upgraded: boolean }> {
+    const { stagedPath, client, dbPath, backupDir } = params;
+
+    // 1. Validate the staged file out-of-band (throws here = nothing mutated yet).
+    const { stagedLatest } = await this.validateStagedDb(stagedPath);
+    const currentLatest = await this.schemaVersionOf(client);
+    const needsUpgrade = stagedLatest !== 'unknown' && stagedLatest !== currentLatest;
+
+    if (params.onBeforeSwap) await params.onBeforeSwap();
+
+    // 2. Safety backup of the CURRENT database. Abort if it can't be made.
+    let safety: SnapshotMetadata;
+    try {
+      safety = await this.createSnapshotFrom({ client, dbPath, backupDir, kind: 'safety', gzip: false });
+    } catch (e) {
+      throw new Error(`Aborting restore: failed to create safety backup: ${e instanceof Error ? e.message : 'unknown'}`);
+    }
+    const safetyPath = path.join(backupDir, safety.filename);
+
+    // 3. Swap the file in, then bring the schema up to date if the backup is older.
+    try {
+      await client.$disconnect();
+      await this.swapInFile(stagedPath, dbPath);
+      await client.$connect();
+      await client.$queryRawUnsafe('SELECT 1');
+      if (needsUpgrade && params.runMigrations) await params.runMigrations();
+      return { safetyBackup: safety.filename, upgraded: needsUpgrade };
+    } catch (err) {
+      // 4. Roll back to the safety backup.
+      try {
+        await client.$disconnect().catch(() => {});
+        await this.swapInFile(safetyPath, dbPath);
+        await client.$connect();
+      } catch (rollbackErr) {
+        throw new Error(
+          `Restore FAILED and automatic rollback also FAILED. Your data may be inconsistent. ` +
+          `Restore the safety backup "${safety.filename}" manually. Original error: ${err instanceof Error ? err.message : 'unknown'}; ` +
+          `rollback error: ${rollbackErr instanceof Error ? rollbackErr.message : 'unknown'}`
+        );
+      }
+      throw new Error(`Restore failed (rolled back to safety backup "${safety.filename}"): ${err instanceof Error ? err.message : 'unknown'}`);
     }
   }
 
@@ -550,9 +603,13 @@ export class BackupService {
     }
   }
 
-  static async getSchemaVersion(): Promise<string> {
+  static getSchemaVersion(): Promise<string> {
+    return this.schemaVersionOf(prisma);
+  }
+
+  static async schemaVersionOf(client: PrismaClient): Promise<string> {
     try {
-      const rows = await prisma.$queryRawUnsafe<Array<{ migration_name: string }>>(
+      const rows = await client.$queryRawUnsafe<Array<{ migration_name: string }>>(
         'SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL ORDER BY finished_at DESC LIMIT 1'
       );
       return rows[0]?.migration_name ?? 'unknown';

--- a/src/tests/api/backup.test.ts
+++ b/src/tests/api/backup.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Backup API tests
+ *
+ * Uses real auth (admin vs non-admin JWTs) so 401/403 are genuinely exercised,
+ * and isolates snapshots to a temp dir so the repo/prod DB are never touched.
+ */
+
+import os from 'os'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { NextRequest } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { testDb, setupTestDatabase, cleanTestDatabase } from '../test-db'
+import { generateTestToken } from '../test-helpers'
+import { BackupService } from '../../lib/backup-service'
+import { GET as listGET, POST as createPOST } from '../../app/api/backup/route'
+import { GET as exportGET } from '../../app/api/backup/export/route'
+import { GET as downloadGET } from '../../app/api/backup/[filename]/download/route'
+import { DELETE as deleteDELETE } from '../../app/api/backup/[filename]/route'
+import { POST as restorePOST } from '../../app/api/backup/restore/route'
+
+let tmpDir: string
+let tempDbUrl: string
+let originalDbUrl: string | undefined
+let adminToken: string
+let userToken: string
+
+function req(method: string, url: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const init: { method: string; headers: Record<string, string>; body?: string } = { method, headers }
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+    init.body = JSON.stringify(body)
+  }
+  return new NextRequest(`http://localhost:3000${url}`, init as ConstructorParameters<typeof NextRequest>[1])
+}
+
+const fileParams = (filename: string) => ({ params: Promise.resolve({ filename }) })
+
+describe('Backup API', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+    originalDbUrl = process.env.DATABASE_URL
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btc-backup-api-'))
+    await fs.copyFile(BackupService.resolveDbPath(), path.join(tmpDir, 'test.db'))
+    tempDbUrl = `file:${path.join(tmpDir, 'test.db')}`
+    process.env.DATABASE_URL = tempDbUrl
+  }, 30000)
+
+  afterAll(async () => {
+    process.env.DATABASE_URL = originalDbUrl
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    await testDb.$disconnect()
+  })
+
+  beforeEach(async () => {
+    process.env.DATABASE_URL = tempDbUrl
+    await fs.rm(BackupService.getBackupDir(), { recursive: true, force: true })
+    await cleanTestDatabase()
+
+    const hash = await bcrypt.hash('pw', 10)
+    const admin = await testDb.user.create({ data: { email: 'admin@test.com', passwordHash: hash, name: 'Admin', isAdmin: true, isActive: true } })
+    const user = await testDb.user.create({ data: { email: 'user@test.com', passwordHash: hash, name: 'User', isAdmin: false, isActive: true } })
+    adminToken = generateTestToken(admin)
+    userToken = generateTestToken(user)
+  })
+
+  describe('auth', () => {
+    it('rejects unauthenticated requests with 401', async () => {
+      const res = await listGET(req('GET', '/api/backup'))
+      expect(res.status).toBe(401)
+    })
+
+    it('rejects non-admin requests with 403', async () => {
+      const res = await listGET(req('GET', '/api/backup', userToken))
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('create / list', () => {
+    it('creates a server snapshot (201) and lists it', async () => {
+      const createRes = await createPOST(req('POST', '/api/backup', adminToken, { gzip: false }))
+      expect(createRes.status).toBe(201)
+      const created = await createRes.json()
+      expect(created.success).toBe(true)
+      expect(created.data.filename).toMatch(/\.db$/)
+
+      // File really exists on disk.
+      await expect(fs.access(BackupService.getSnapshotPath(created.data.filename))).resolves.toBeUndefined()
+
+      const listRes = await listGET(req('GET', '/api/backup', adminToken))
+      expect(listRes.status).toBe(200)
+      const list = await listRes.json()
+      expect(list.data.map((s: { filename: string }) => s.filename)).toContain(created.data.filename)
+    })
+  })
+
+  describe('export', () => {
+    it('streams an on-the-fly snapshot as an attachment', async () => {
+      const res = await exportGET(req('GET', '/api/backup/export', adminToken))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+      expect(res.headers.get('content-disposition')).toMatch(/attachment; filename=/)
+      // Not retained server-side.
+      const list = await BackupService.listSnapshots()
+      expect(list).toHaveLength(0)
+    })
+  })
+
+  describe('download', () => {
+    it('downloads an existing snapshot', async () => {
+      const created = await (await createPOST(req('POST', '/api/backup', adminToken, { gzip: false }))).json()
+      const res = await downloadGET(req('GET', `/api/backup/${created.data.filename}/download`, adminToken), fileParams(created.data.filename))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+    })
+
+    it('returns 404 for a missing snapshot', async () => {
+      const res = await downloadGET(req('GET', '/api/backup/nope.db/download', adminToken), fileParams('nope.db'))
+      expect(res.status).toBe(404)
+    })
+
+    it('rejects path traversal with 400', async () => {
+      const res = await downloadGET(req('GET', '/api/backup/x/download', adminToken), fileParams('../../etc/passwd'))
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes a snapshot', async () => {
+      const created = await (await createPOST(req('POST', '/api/backup', adminToken, { gzip: false }))).json()
+      const res = await deleteDELETE(req('DELETE', `/api/backup/${created.data.filename}`, adminToken), fileParams(created.data.filename))
+      expect(res.status).toBe(200)
+      expect(await BackupService.listSnapshots()).toHaveLength(0)
+    })
+
+    it('rejects path traversal with 400', async () => {
+      const res = await deleteDELETE(req('DELETE', '/api/backup/x', adminToken), fileParams('../../etc/passwd'))
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('restore', () => {
+    it('rejects non-admin with 403', async () => {
+      const res = await restorePOST(req('POST', '/api/backup/restore', userToken, { filename: 'x.db' }))
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 400 when no filename is provided (JSON body)', async () => {
+      const res = await restorePOST(req('POST', '/api/backup/restore', adminToken, {}))
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 409 when a restore is already in progress', async () => {
+      const spy = jest.spyOn(BackupService, 'isRestoreInProgress').mockReturnValue(true)
+      const res = await restorePOST(req('POST', '/api/backup/restore', adminToken, { filename: 'x.db' }))
+      expect(res.status).toBe(409)
+      spy.mockRestore()
+    })
+  })
+})

--- a/src/tests/backup-restore.test.ts
+++ b/src/tests/backup-restore.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Backup → restore integrity tests.
+ *
+ * These exercise the REAL destructive path (createSnapshotFrom + restoreCore:
+ * validate → safety backup → file swap → reconnect → migrate/rollback) against
+ * fully isolated throwaway databases and dedicated PrismaClients, so the shared
+ * test DB and the global Prisma singleton are never touched.
+ */
+
+import os from 'os'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { gunzipSync } from 'zlib'
+import { PrismaClient } from '@prisma/client'
+import { setupTestDatabase } from './test-db'
+import { BackupService } from '../lib/backup-service'
+
+let baseDb: string
+let migLatest: string
+let migOlder: string
+let tmpRoot: string
+
+/** Make an isolated copy of the schema'd test DB with a chosen migration marker. */
+async function isolatedDb(file: string, migration: string, markerEmail?: string): Promise<PrismaClient> {
+  await fs.copyFile(baseDb, file)
+  const client = new PrismaClient({ datasources: { db: { url: `file:${file}` } } })
+  await client.$connect()
+  await client.$executeRawUnsafe('CREATE TABLE IF NOT EXISTS "_prisma_migrations" ("id" TEXT PRIMARY KEY, "migration_name" TEXT NOT NULL, "finished_at" DATETIME)')
+  await client.$executeRawUnsafe('DELETE FROM "_prisma_migrations"')
+  await client.$executeRawUnsafe(`INSERT INTO "_prisma_migrations" ("id","migration_name","finished_at") VALUES ('${migration}','${migration}', CURRENT_TIMESTAMP)`)
+  if (markerEmail) await client.user.create({ data: { email: markerEmail, passwordHash: 'x' } })
+  return client
+}
+
+const hasUser = async (client: PrismaClient, email: string) =>
+  (await client.user.findUnique({ where: { email } })) !== null
+
+describe('Backup → restore integrity', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+    baseDb = BackupService.resolveDbPath()
+    const migs = (await fs.readdir(path.join(process.cwd(), 'prisma', 'migrations'), { withFileTypes: true }))
+      .filter((d) => d.isDirectory()).map((d) => d.name).sort()
+    migLatest = migs[migs.length - 1]
+    migOlder = migs[0]
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'btc-restore-'))
+  }, 30000)
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('round-trips data: snapshot → delete → restore brings it back', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpRoot, 'rt-'))
+    const file = path.join(dir, 'db.db')
+    const backupDir = path.join(dir, 'backups')
+    const client = await isolatedDb(file, migLatest, 'rt-marker@test.com')
+
+    try {
+      const snap = await BackupService.createSnapshotFrom({ client, dbPath: file, backupDir, gzip: false })
+
+      await client.user.deleteMany({ where: { email: 'rt-marker@test.com' } })
+      expect(await hasUser(client, 'rt-marker@test.com')).toBe(false)
+
+      const staged = path.join(dir, 'staged.db')
+      await fs.copyFile(path.join(backupDir, snap.filename), staged)
+
+      const result = await BackupService.restoreCore({ stagedPath: staged, client, dbPath: file, backupDir })
+      expect(result.upgraded).toBe(false)
+      expect(await hasUser(client, 'rt-marker@test.com')).toBe(true)
+    } finally {
+      await client.$disconnect()
+    }
+  })
+
+  it('round-trips a gzip snapshot', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpRoot, 'gz-'))
+    const file = path.join(dir, 'db.db')
+    const backupDir = path.join(dir, 'backups')
+    const client = await isolatedDb(file, migLatest, 'gz-marker@test.com')
+
+    try {
+      const snap = await BackupService.createSnapshotFrom({ client, dbPath: file, backupDir, gzip: true })
+      expect(snap.filename.endsWith('.db.gz')).toBe(true)
+
+      await client.user.deleteMany({ where: { email: 'gz-marker@test.com' } })
+
+      // Decompress like the upload path does, then restore.
+      const staged = path.join(dir, 'staged.db')
+      await fs.writeFile(staged, gunzipSync(await fs.readFile(path.join(backupDir, snap.filename))))
+
+      await BackupService.restoreCore({ stagedPath: staged, client, dbPath: file, backupDir })
+      expect(await hasUser(client, 'gz-marker@test.com')).toBe(true)
+    } finally {
+      await client.$disconnect()
+    }
+  })
+
+  it('runs the migration upgrade hook when the backup is older', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpRoot, 'up-'))
+    const file = path.join(dir, 'db.db')
+    const backupDir = path.join(dir, 'backups')
+    const current = await isolatedDb(file, migLatest)            // live DB at latest migration
+    const sourceFile = path.join(dir, 'src.db')
+    const source = await isolatedDb(sourceFile, migOlder)        // backup from an older migration
+
+    try {
+      const snap = await BackupService.createSnapshotFrom({ client: source, dbPath: sourceFile, backupDir, gzip: false })
+      await source.$disconnect()
+
+      const staged = path.join(dir, 'staged.db')
+      await fs.copyFile(path.join(backupDir, snap.filename), staged)
+
+      const runMigrations = jest.fn().mockResolvedValue(undefined)
+      const result = await BackupService.restoreCore({ stagedPath: staged, client: current, dbPath: file, backupDir, runMigrations })
+
+      expect(result.upgraded).toBe(true)
+      expect(runMigrations).toHaveBeenCalledTimes(1)
+    } finally {
+      await current.$disconnect()
+    }
+  })
+
+  it('rolls back to the safety backup (restoring original data) when restore fails', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpRoot, 'rb-'))
+    const file = path.join(dir, 'db.db')
+    const backupDir = path.join(dir, 'backups')
+    const current = await isolatedDb(file, migLatest, 'CURRENT@test.com')   // live data we must not lose
+    const sourceFile = path.join(dir, 'src.db')
+    const source = await isolatedDb(sourceFile, migOlder, 'OTHER@test.com')  // older → triggers migrate hook
+
+    try {
+      const snap = await BackupService.createSnapshotFrom({ client: source, dbPath: sourceFile, backupDir, gzip: false })
+      await source.$disconnect()
+
+      const staged = path.join(dir, 'staged.db')
+      await fs.copyFile(path.join(backupDir, snap.filename), staged)
+
+      // Migration hook throws AFTER the swap → must roll back to the safety backup.
+      const runMigrations = jest.fn().mockRejectedValue(new Error('boom'))
+      await expect(
+        BackupService.restoreCore({ stagedPath: staged, client: current, dbPath: file, backupDir, runMigrations })
+      ).rejects.toThrow(/rolled back/i)
+
+      // Original data is back; the failed restore's data is not present.
+      expect(await hasUser(current, 'CURRENT@test.com')).toBe(true)
+      expect(await hasUser(current, 'OTHER@test.com')).toBe(false)
+    } finally {
+      await current.$disconnect()
+    }
+  })
+})

--- a/src/tests/backup-scheduler.test.ts
+++ b/src/tests/backup-scheduler.test.ts
@@ -1,0 +1,75 @@
+/**
+ * BackupScheduler tests (isolated temp dir, fake timers for interval behaviour).
+ */
+
+import os from 'os'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { setupTestDatabase } from './test-db'
+import { BackupService } from '../lib/backup-service'
+import { BackupScheduler } from '../lib/backup-scheduler'
+
+let tmpDir: string
+let tempDbUrl: string
+let originalDbUrl: string | undefined
+
+describe('BackupScheduler', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+    originalDbUrl = process.env.DATABASE_URL
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btc-backup-sched-'))
+    await fs.copyFile(BackupService.resolveDbPath(), path.join(tmpDir, 'test.db'))
+    tempDbUrl = `file:${path.join(tmpDir, 'test.db')}`
+    process.env.DATABASE_URL = tempDbUrl
+  }, 30000)
+
+  afterAll(async () => {
+    process.env.DATABASE_URL = originalDbUrl
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    process.env.DATABASE_URL = tempDbUrl
+    BackupScheduler.stop()
+    await fs.rm(BackupService.getBackupDir(), { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    BackupScheduler.stop()
+    jest.useRealTimers()
+  })
+
+  it('does not schedule when disabled', async () => {
+    await BackupService.saveConfig({ enabled: false })
+    await BackupScheduler.start()
+    expect(BackupScheduler.getStatus().scheduled).toBe(false)
+  })
+
+  it('schedules an interval when enabled', async () => {
+    jest.useFakeTimers()
+    await BackupService.saveConfig({ enabled: true, intervalHours: 1 })
+    await BackupScheduler.start()
+    expect(BackupScheduler.getStatus().scheduled).toBe(true)
+    BackupScheduler.stop()
+    expect(BackupScheduler.getStatus().scheduled).toBe(false)
+  })
+
+  it('runNow creates a scheduled snapshot and applies retention', async () => {
+    await BackupService.saveConfig({ enabled: true, gzip: false, retention: { keepLast: 2, keepDays: null } })
+
+    const a = await BackupScheduler.runNow()
+    const b = await BackupScheduler.runNow()
+    const c = await BackupScheduler.runNow()
+
+    expect(a.kind).toBe('scheduled')
+    const remaining = (await BackupService.listSnapshots()).filter((s) => s.kind === 'scheduled')
+    // keepLast=2 → only the two newest scheduled survive.
+    expect(remaining).toHaveLength(2)
+    expect(remaining.map((s) => s.filename)).toContain(c.filename)
+    expect(remaining.map((s) => s.filename)).not.toContain(a.filename)
+
+    const cfg = await BackupService.getConfig()
+    expect(cfg.lastRunAt).not.toBeNull()
+    expect(cfg.lastError).toBeNull()
+  })
+})

--- a/src/tests/backup-service.test.ts
+++ b/src/tests/backup-service.test.ts
@@ -1,0 +1,209 @@
+/**
+ * BackupService unit tests
+ *
+ * Runs against an isolated temp directory (DATABASE_URL is pointed at a copy of
+ * the test DB) so it never touches real backups or the production database.
+ */
+
+import os from 'os'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { gunzipSync } from 'zlib'
+import { PrismaClient } from '@prisma/client'
+import { setupTestDatabase } from './test-db'
+import { BackupService } from '../lib/backup-service'
+
+const SQLITE_MAGIC = 'SQLite format 3\0'
+
+let tmpDir: string
+let tempDbUrl: string
+let originalDbUrl: string | undefined
+
+async function makeFakeSnapshot(filename: string, kind: string, createdAt: string) {
+  const dir = BackupService.getBackupDir()
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, filename), SQLITE_MAGIC + 'fakedata')
+  const meta = { filename, sizeBytes: 16, createdAt, appVersion: 'x', schemaVersion: 'y', gzip: filename.endsWith('.gz'), kind }
+  await fs.writeFile(path.join(dir, `${filename}.json`), JSON.stringify(meta))
+}
+
+describe('BackupService', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+
+    originalDbUrl = process.env.DATABASE_URL
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btc-backup-test-'))
+
+    // Copy the real test DB (resolved the way Prisma resolves it) so
+    // resolveDbPath()/stat() see a real file, then isolate to the temp dir.
+    const realDb = BackupService.resolveDbPath()
+    await fs.copyFile(realDb, path.join(tmpDir, 'test.db'))
+    tempDbUrl = `file:${path.join(tmpDir, 'test.db')}`
+    process.env.DATABASE_URL = tempDbUrl
+  }, 30000)
+
+  afterAll(async () => {
+    process.env.DATABASE_URL = originalDbUrl
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    // Reset env first (a test that overrides DATABASE_URL and throws must not
+    // leak it) and isolate each test by wiping the backup dir.
+    process.env.DATABASE_URL = tempDbUrl
+    await fs.rm(BackupService.getBackupDir(), { recursive: true, force: true })
+  })
+
+  describe('path resolution', () => {
+    it('resolves absolute file: URLs as-is', () => {
+      process.env.DATABASE_URL = 'file:/var/data/app.db'
+      expect(BackupService.resolveDbPath()).toBe('/var/data/app.db')
+      expect(BackupService.getBackupDir()).toBe(path.join('/var/data', 'backups'))
+    })
+
+    it('resolves relative file: URLs against the prisma schema dir', () => {
+      // `file:./test.db` actually lives at `prisma/test.db` (Prisma resolves
+      // relative SQLite paths against the schema dir).
+      process.env.DATABASE_URL = 'file:./test.db'
+      expect(BackupService.resolveDbPath()).toBe(path.resolve(process.cwd(), 'prisma', 'test.db'))
+    })
+
+    it('rejects non-file URLs', () => {
+      process.env.DATABASE_URL = 'postgresql://localhost/db'
+      expect(() => BackupService.resolveDbPath()).toThrow()
+    })
+
+    it('guards getSnapshotPath against traversal', () => {
+      expect(() => BackupService.getSnapshotPath('../../etc/passwd')).toThrow()
+      expect(() => BackupService.getSnapshotPath('sub/dir.db')).toThrow()
+      const ok = BackupService.getSnapshotPath('btc-backup-x.db')
+      expect(ok.startsWith(BackupService.getBackupDir())).toBe(true)
+    })
+  })
+
+  describe('createSnapshot', () => {
+    it('produces a valid SQLite snapshot with metadata sidecar', async () => {
+      const meta = await BackupService.createSnapshot({ kind: 'manual', gzip: false })
+
+      expect(meta.kind).toBe('manual')
+      expect(meta.gzip).toBe(false)
+      expect(meta.sha256).toMatch(/^[a-f0-9]{64}$/)
+      expect(meta.sizeBytes).toBeGreaterThan(0)
+
+      const buf = await BackupService.readSnapshot(meta.filename)
+      expect(buf.subarray(0, SQLITE_MAGIC.length).toString('binary')).toBe(SQLITE_MAGIC)
+
+      // Sidecar exists and round-trips.
+      const sidecar = JSON.parse(await fs.readFile(path.join(BackupService.getBackupDir(), `${meta.filename}.json`), 'utf-8'))
+      expect(sidecar.filename).toBe(meta.filename)
+    })
+
+    it('gzips and the snapshot gunzips back to a valid SQLite file', async () => {
+      const meta = await BackupService.createSnapshot({ kind: 'scheduled', gzip: true })
+      expect(meta.filename.endsWith('.db.gz')).toBe(true)
+
+      const gz = await BackupService.readSnapshot(meta.filename)
+      const plain = gunzipSync(gz)
+      expect(plain.subarray(0, SQLITE_MAGIC.length).toString('binary')).toBe(SQLITE_MAGIC)
+    })
+
+    it('aborts when there is not enough disk space', async () => {
+      const spy = jest.spyOn(BackupService, 'freeDiskBytes').mockResolvedValue(0)
+      await expect(BackupService.createSnapshot({ kind: 'manual' })).rejects.toThrow(/disk space/i)
+      spy.mockRestore()
+    })
+  })
+
+  describe('list / delete', () => {
+    it('lists snapshots newest-first and synthesizes metadata for orphans', async () => {
+      await makeFakeSnapshot('btc-backup-2024-01-01.db', 'manual', '2024-01-01T00:00:00.000Z')
+      await makeFakeSnapshot('btc-backup-2024-03-01.db', 'manual', '2024-03-01T00:00:00.000Z')
+      // Orphan with no sidecar:
+      const dir = BackupService.getBackupDir()
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(path.join(dir, 'btc-backup-orphan.db'), SQLITE_MAGIC)
+
+      const list = await BackupService.listSnapshots()
+      expect(list).toHaveLength(3)
+      expect(list[0].createdAt >= list[1].createdAt).toBe(true)
+      const orphan = list.find((s) => s.filename === 'btc-backup-orphan.db')
+      expect(orphan?.appVersion).toBe('unknown')
+    })
+
+    it('deletes a snapshot and its sidecar', async () => {
+      await makeFakeSnapshot('btc-backup-del.db', 'manual', '2024-01-01T00:00:00.000Z')
+      await BackupService.deleteSnapshot('btc-backup-del.db')
+      const list = await BackupService.listSnapshots()
+      expect(list).toHaveLength(0)
+      await expect(fs.access(path.join(BackupService.getBackupDir(), 'btc-backup-del.db.json'))).rejects.toThrow()
+    })
+  })
+
+  describe('applyRetention', () => {
+    it('keeps the newest N scheduled and never deletes manual/safety', async () => {
+      await makeFakeSnapshot('btc-backup-auto-1.db', 'scheduled', '2024-01-01T00:00:00.000Z')
+      await makeFakeSnapshot('btc-backup-auto-2.db', 'scheduled', '2024-02-01T00:00:00.000Z')
+      await makeFakeSnapshot('btc-backup-auto-3.db', 'scheduled', '2024-03-01T00:00:00.000Z')
+      await makeFakeSnapshot('btc-backup-manual.db', 'manual', '2020-01-01T00:00:00.000Z')
+      await makeFakeSnapshot('pre-restore-x.db', 'safety', '2020-01-01T00:00:00.000Z')
+
+      const deleted = await BackupService.applyRetention({ keepLast: 2 })
+      expect(deleted).toEqual(['btc-backup-auto-1.db'])
+
+      const remaining = (await BackupService.listSnapshots()).map((s) => s.filename).sort()
+      expect(remaining).toContain('btc-backup-manual.db')
+      expect(remaining).toContain('pre-restore-x.db')
+      expect(remaining).not.toContain('btc-backup-auto-1.db')
+    })
+
+    it('deletes scheduled snapshots older than keepDays', async () => {
+      const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString()
+      const recent = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString()
+      await makeFakeSnapshot('btc-backup-auto-old.db', 'scheduled', old)
+      await makeFakeSnapshot('btc-backup-auto-recent.db', 'scheduled', recent)
+
+      const deleted = await BackupService.applyRetention({ keepDays: 30 })
+      expect(deleted).toEqual(['btc-backup-auto-old.db'])
+    })
+  })
+
+  describe('config', () => {
+    it('returns defaults when no config file exists', async () => {
+      const cfg = await BackupService.getConfig()
+      expect(cfg.enabled).toBe(false)
+      expect(cfg.retention.keepLast).toBe(7)
+    })
+
+    it('persists and deep-merges retention on save', async () => {
+      await BackupService.saveConfig({ enabled: true, retention: { keepLast: 3 } })
+      const cfg = await BackupService.getConfig()
+      expect(cfg.enabled).toBe(true)
+      expect(cfg.retention.keepLast).toBe(3)
+      expect(cfg.retention.keepDays).toBe(30) // default preserved
+    })
+  })
+
+  describe('restore validation', () => {
+    // These reject during validation, BEFORE any destructive action (safety
+    // backup / file swap), so they never touch the live DB.
+
+    it('rejects a non-SQLite upload and releases the lock', async () => {
+      await expect(BackupService.restoreFromBuffer(Buffer.from('definitely not a sqlite database')))
+        .rejects.toThrow(/not a SQLite/i)
+      expect(BackupService.isRestoreInProgress()).toBe(false)
+    })
+
+    it('rejects a SQLite db missing required tables', async () => {
+      // Build a minimal valid SQLite file that lacks our schema.
+      const emptyPath = path.join(tmpDir, 'empty.db')
+      const p = new PrismaClient({ datasources: { db: { url: `file:${emptyPath}` } } })
+      await p.$executeRawUnsafe('CREATE TABLE dummy (id INTEGER)')
+      await p.$disconnect()
+
+      const buf = await fs.readFile(emptyPath)
+      await expect(BackupService.restoreFromBuffer(buf)).rejects.toThrow(/missing required table/i)
+      expect(BackupService.isRestoreInProgress()).toBe(false)
+      await fs.rm(emptyPath, { force: true })
+    })
+  })
+})


### PR DESCRIPTION
## What
Admin-only **Backup & Restore** integrated into Settings → Backup.

- **Download backup** / **create server snapshot** (full SQLite DB via `VACUUM INTO`, WAL-safe, optional gzip)
- **Server snapshots**: list / download / restore / delete
- **Restore from file** (drag-drop): out-of-band validation (magic header, required tables, refuses newer-than-known migrations), **automatic safety backup**, single-flight locked swap (clears `-wal`/`-shm`), reconnect, migrate-up if the backup is older, and **rollback to the safety backup** on failure
- **Automatic backups**: scheduler + retention (keep last N / keep N days), wired into app init
- Destructive restore requires typing `RESTORE`; warns about the `NEXTAUTH_SECRET` encryption caveat and that you may need to re-login

## Design notes
- Full-file model (all users' data) → admin only; matches the existing 'single SQLite file' backup story
- DB path resolved from `DATABASE_URL` (works for dev / Docker / Electron)
- Schedule config stored on disk (`backups/backup-config.json`), not in the DB, so a restore can't silently overwrite the schedule
- Retention deliberately avoids `Set` iteration: tsconfig targets es5 and ts-jest silently mis-compiles `Set` spread/iteration under es5

## Tests / verification
- 30 new tests (BackupService, scheduler, API with real admin/non-admin auth, restore validation + rollback paths)
- Full suite **272 passing**, `tsc --noEmit` clean, `next build` compiles with no warnings

## Known limitation (flagged, not blocking)
- Restoring an **older** backup under the packaged **Electron** app needs the bundled Prisma CLI for the schema upgrade; same-version restore works everywhere. Cross-version Electron upgrade is a follow-up.
- Large-DB download/upload currently buffers in memory; streaming is a future enhancement.

Separate PR from the security/CI work; targets `dev`.